### PR TITLE
Add basic Elm support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,3 +36,5 @@ pomExtra in Global := {
     </developer>
   </developers>
 }
+
+scalafmtOnCompile := true

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,8 @@ name         in ThisBuild := "bridges"
 organization in ThisBuild := "com.davegurnell"
 version      in ThisBuild := "0.3.2"
 
-scalaVersion       in ThisBuild := "2.12.1"
-crossScalaVersions in ThisBuild := Seq("2.11.8", "2.12.1")
+scalaVersion       in ThisBuild := "2.12.6"
+crossScalaVersions in ThisBuild := Seq("2.11.8", "2.12.6")
 
 licenses += ("Apache-2.0", url("http://apache.org/licenses/LICENSE-2.0"))
 
@@ -15,10 +15,10 @@ scalacOptions ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "com.chuusai"       %% "shapeless"     % "2.3.2",
+  "com.chuusai"       %% "shapeless"     % "2.3.3",
   "com.davegurnell"   %% "unindent"      % "1.1.0",
   "org.apache.commons" % "commons-lang3" % "3.5",
-  "org.scalatest"     %% "scalatest"     % "3.0.1" % Test
+  "org.scalatest"     %% "scalatest"     % "3.0.5" % Test
 )
 
 pomExtra in Global := {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=1.1.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.6.0-RC1")

--- a/src/main/scala/bridges/Encoder.scala
+++ b/src/main/scala/bridges/Encoder.scala
@@ -28,17 +28,23 @@ trait EncoderInstances2 extends EncoderInstances1 {
   implicit val stringEncoder: BasicEncoder[String] =
     pure(Str)
 
+  implicit val charEncoder: BasicEncoder[Char] =
+    pure(Character)
+
   implicit val intEncoder: BasicEncoder[Int] =
     pure(Num)
 
   implicit val doubleEncoder: BasicEncoder[Double] =
-    pure(Num)
+    pure(Floating)
+
+  implicit val floatEncoder: BasicEncoder[Float] =
+    pure(Floating)
 
   implicit val booleanEncoder: BasicEncoder[Boolean] =
     pure(Bool)
 
   implicit def optionEncoder[A](implicit enc: BasicEncoder[A]): BasicEncoder[Option[A]] =
-    pure(enc.encode | Null)
+  pure(Optional(enc.encode))
 
   implicit def traversableEncoder[F[_] <: Traversable[_], A](implicit enc: BasicEncoder[A]): BasicEncoder[F[A]] =
     pure(Array(enc.encode))

--- a/src/main/scala/bridges/Encoder.scala
+++ b/src/main/scala/bridges/Encoder.scala
@@ -94,17 +94,20 @@ trait EncoderInstances1 extends EncoderInstances0 {
   implicit def cnilUnionEncoder: UnionEncoder[CNil] =
     pureUnion(Union(Nil))
 
+  // we should always have a StructEncoder for H as on a Coproduct
   implicit def cconsUnionEncoder[K <: Symbol, H, T <: Coproduct](
       implicit
       witness: Witness.Aux[K],
       hEnc: Lazy[BasicEncoder[H]],
+      hEncFields: Lazy[StructEncoder[H]],
       tEnc: UnionEncoder[T]
   ): UnionEncoder[FieldType[K, H] :+: T] = {
     val name = witness.value.name
     val head = hEnc.value.encode
+    val headFields = hEncFields.value.encode
     val tail = tEnc.encode
 
-    pureUnion(disc(name, head) +: tail)
+    pureUnion(disc(name, head, headFields) +: tail)
   }
 
   implicit def genericStructEncoder[A, L](

--- a/src/main/scala/bridges/Encoder.scala
+++ b/src/main/scala/bridges/Encoder.scala
@@ -1,5 +1,7 @@
 package bridges
 
+import bridges.syntax.typeName
+
 import scala.language.higherKinds
 import shapeless.labelled.FieldType
 import shapeless.{:+:, ::, CNil, Coproduct, HList, HNil, LabelledGeneric, Lazy, LowPriority, Typeable, Unwrapped, Witness}
@@ -90,7 +92,7 @@ trait EncoderInstances0 extends EncoderConstructors {
   import Type._
 
   implicit def genericBasicEncoder[A](implicit typeable: Typeable[A], low: LowPriority): BasicEncoder[A] =
-    pure(Ref(typeable.describe))
+    pure(Ref(typeName[A]))
 }
 
 trait EncoderConstructors {

--- a/src/main/scala/bridges/Encoder.scala
+++ b/src/main/scala/bridges/Encoder.scala
@@ -4,7 +4,20 @@ import bridges.syntax.typeName
 
 import scala.language.higherKinds
 import shapeless.labelled.FieldType
-import shapeless.{:+:, ::, CNil, Coproduct, HList, HNil, LabelledGeneric, Lazy, LowPriority, Typeable, Unwrapped, Witness}
+import shapeless.{
+  :+:,
+  ::,
+  CNil,
+  Coproduct,
+  HList,
+  HNil,
+  LabelledGeneric,
+  Lazy,
+  LowPriority,
+  Typeable,
+  Unwrapped,
+  Witness
+}
 
 trait Encoder[A] {
   def encode: Type
@@ -43,13 +56,20 @@ trait EncoderInstances2 extends EncoderInstances1 {
   implicit val booleanEncoder: BasicEncoder[Boolean] =
     pure(Bool)
 
-  implicit def optionEncoder[A](implicit enc: BasicEncoder[A]): BasicEncoder[Option[A]] =
-  pure(Optional(enc.encode))
+  implicit def optionEncoder[A](
+      implicit enc: BasicEncoder[A]
+  ): BasicEncoder[Option[A]] =
+    pure(Optional(enc.encode))
 
-  implicit def traversableEncoder[F[_] <: Traversable[_], A](implicit enc: BasicEncoder[A]): BasicEncoder[F[A]] =
+  implicit def traversableEncoder[F[_] <: Traversable[_], A](
+      implicit enc: BasicEncoder[A]
+  ): BasicEncoder[F[A]] =
     pure(Array(enc.encode))
 
-  implicit def valueClassEncoder[A <: AnyVal, B](implicit unwrapped: Unwrapped.Aux[A, B], encoder: BasicEncoder[B]): BasicEncoder[A] =
+  implicit def valueClassEncoder[A <: AnyVal, B](
+      implicit unwrapped: Unwrapped.Aux[A, B],
+      encoder: BasicEncoder[B]
+  ): BasicEncoder[A] =
     pure(encoder.encode)
 }
 
@@ -60,10 +80,10 @@ trait EncoderInstances1 extends EncoderInstances0 {
     pureStruct(Struct(Nil))
 
   implicit def hconsEncoder[K <: Symbol, H, T <: HList](
-    implicit
-    witness: Witness.Aux[K],
-    hEnc: Lazy[BasicEncoder[H]],
-    tEnc   : StructEncoder[T]
+      implicit
+      witness: Witness.Aux[K],
+      hEnc: Lazy[BasicEncoder[H]],
+      tEnc: StructEncoder[T]
   ): StructEncoder[FieldType[K, H] :: T] = {
     val name = witness.value.name
     val head = hEnc.value.encode
@@ -75,10 +95,10 @@ trait EncoderInstances1 extends EncoderInstances0 {
     pureUnion(Union(Nil))
 
   implicit def cconsUnionEncoder[K <: Symbol, H, T <: Coproduct](
-    implicit
-    witness: Witness.Aux[K],
-    hEnc   : Lazy[BasicEncoder[H]],
-    tEnc   : UnionEncoder[T]
+      implicit
+      witness: Witness.Aux[K],
+      hEnc: Lazy[BasicEncoder[H]],
+      tEnc: UnionEncoder[T]
   ): UnionEncoder[FieldType[K, H] :+: T] = {
     val name = witness.value.name
     val head = hEnc.value.encode
@@ -87,17 +107,26 @@ trait EncoderInstances1 extends EncoderInstances0 {
     pureUnion(disc(name, head) +: tail)
   }
 
-  implicit def genericStructEncoder[A, L](implicit gen: LabelledGeneric.Aux[A, L], enc: Lazy[StructEncoder[L]]): StructEncoder[A] =
+  implicit def genericStructEncoder[A, L](
+      implicit gen: LabelledGeneric.Aux[A, L],
+      enc: Lazy[StructEncoder[L]]
+  ): StructEncoder[A] =
     pureStruct(enc.value.encode)
 
-  implicit def genericUnionEncoder[A, L](implicit gen: LabelledGeneric.Aux[A, L], enc: Lazy[UnionEncoder[L]]): UnionEncoder[A] =
+  implicit def genericUnionEncoder[A, L](
+      implicit gen: LabelledGeneric.Aux[A, L],
+      enc: Lazy[UnionEncoder[L]]
+  ): UnionEncoder[A] =
     pureUnion(enc.value.encode)
 }
 
 trait EncoderInstances0 extends EncoderConstructors {
   import Type._
 
-  implicit def genericBasicEncoder[A](implicit typeable: Typeable[A], low: LowPriority): BasicEncoder[A] =
+  implicit def genericBasicEncoder[A](
+      implicit typeable: Typeable[A],
+      low: LowPriority
+  ): BasicEncoder[A] =
     pure(Ref(typeName[A]))
 }
 

--- a/src/main/scala/bridges/Renderer.scala
+++ b/src/main/scala/bridges/Renderer.scala
@@ -6,7 +6,7 @@ trait Renderer[A] {
   def render(decls: List[Declaration]): String
 }
 
-trait BaseRenderer[A] extends Renderer[A] {
+trait TypescriptStyleRenderer[A] extends Renderer[A] {
   import Type._
 
   def render(decls: List[Declaration]): String =
@@ -19,13 +19,17 @@ trait BaseRenderer[A] extends Renderer[A] {
     tpe match {
       case Ref(id)             => id
       case StrLiteral(str)     => "\"" + escape(str) + "\""
+      case CharLiteral(ch)     => "\"" + ch + "\""
       case NumLiteral(num)     => num.toString
+      case FloatingLiteral(fl) => fl.toString
       case BoolLiteral(bool)   => bool.toString
       case Str                 => "string"
+      case Character           => "string"
       case Num                 => "number"
+      case Floating            => "number"
       case Bool                => "boolean"
-      case Null                => "null"
-      case Array(tpe)          => "Array<" + renderType(tpe) + ">"
+      case Optional(optTpe)    => "(" + renderType(optTpe) + " | null)"
+      case Array(arrTpe)       => "Array<" + renderType(arrTpe) + ">"
       case Struct(fields)      => fields.map(renderField).mkString("{ ", ", ", " }")
       case Union(types)        => types.map(renderType).mkString("(", " | ", ")")
       case Intersection(types) => types.map(renderType).mkString("(", " & ", ")")
@@ -35,7 +39,46 @@ trait BaseRenderer[A] extends Renderer[A] {
     s"""${field._1}: ${renderType(field._2)}"""
 }
 
+trait ElmStyleRenderer[A] extends Renderer[A] {
+  import Type._
+
+  def render(decls: List[Declaration]): String =
+    decls.map(render).mkString("\n\n")
+
+  def render(decl: Declaration): String =
+    decl.tpe match {
+      case Union(types) ⇒ s"type ${decl.id} = ${types.map(renderType).mkString(" | ")}"
+      case other ⇒ s"type alias ${decl.id} = ${renderType(other)}"
+    }
+
+  def renderType(tpe: Type): String =
+    tpe match {
+      case Ref(id)             => id
+      case StrLiteral(str)     => "\"" + escape(str) + "\""
+      case CharLiteral(ch)     => "'" + ch + "'"
+      case NumLiteral(num)     => num.toString
+      case FloatingLiteral(fl) => fl.toString
+      case BoolLiteral(bool)   => bool.toString
+      case Str                 => "String"
+      case Character           => "Char"
+      case Num                 => "Int"
+      case Floating            => "Float"
+      case Bool                => "Bool"
+      case Optional(optTpe)    => "Maybe " + renderType(optTpe)
+      case Array(arrTpe)       => "List " + renderType(arrTpe)
+      case Struct(fields)      => fields.map(renderField).mkString("{ ", ", ", " }")
+      case Union(types)        => types.map(renderType).mkString(" | ")
+      case Intersection(types) =>
+          // Elm doesn't support intersection types. To support compatibility with Typescript we just ignore the Struct part of the Intersection and treat it as union
+          types.collect{ case c: Ref ⇒ c }.map(renderType).mkString(" | ")
+    }
+
+  def renderField(field: (String, Type)): String =
+    s"""${field._1}: ${renderType(field._2)}"""
+}
+
 object Renderer {
-  implicit object TypescriptRenderer extends BaseRenderer[Typescript]
-  implicit object FlowRenderer extends BaseRenderer[Flow]
+  implicit object TypescriptRenderer extends TypescriptStyleRenderer[Typescript]
+  implicit object FlowRenderer extends TypescriptStyleRenderer[Flow]
+  implicit object ElmRenderer extends ElmStyleRenderer[Elm]
 }

--- a/src/main/scala/bridges/Renderer.scala
+++ b/src/main/scala/bridges/Renderer.scala
@@ -32,7 +32,8 @@ trait TypescriptStyleRenderer[A] extends Renderer[A] {
       case Array(arrTpe)       => "Array<" + renderType(arrTpe) + ">"
       case Struct(fields)      => fields.map(renderField).mkString("{ ", ", ", " }")
       case Union(types)        => types.map(renderType).mkString("(", " | ", ")")
-      case Intersection(types) => types.map(renderType).mkString("(", " & ", ")")
+      case Intersection(types) =>
+        types.map(renderType).mkString("(", " & ", ")")
     }
 
   def renderField(field: (String, Type)): String =
@@ -47,7 +48,8 @@ trait ElmStyleRenderer[A] extends Renderer[A] {
 
   def render(decl: Declaration): String =
     decl.tpe match {
-      case Union(types) ⇒ s"type ${decl.id} = ${types.map(renderType).mkString(" | ")}"
+      case Union(types) ⇒
+        s"type ${decl.id} = ${types.map(renderType).mkString(" | ")}"
       case other ⇒ s"type alias ${decl.id} = ${renderType(other)}"
     }
 
@@ -69,8 +71,8 @@ trait ElmStyleRenderer[A] extends Renderer[A] {
       case Struct(fields)      => fields.map(renderField).mkString("{ ", ", ", " }")
       case Union(types)        => types.map(renderType).mkString(" | ")
       case Intersection(types) =>
-          // Elm doesn't support intersection types. To support compatibility with Typescript we just ignore the Struct part of the Intersection and treat it as union
-          types.collect{ case c: Ref ⇒ c }.map(renderType).mkString(" | ")
+        // Elm doesn't support intersection types. To support compatibility with Typescript we just ignore the Struct part of the Intersection and treat it as union
+        types.collect { case c: Ref ⇒ c }.map(renderType).mkString(" | ")
     }
 
   def renderField(field: (String, Type)): String =

--- a/src/main/scala/bridges/Target.scala
+++ b/src/main/scala/bridges/Target.scala
@@ -7,3 +7,6 @@ case object Typescript extends Typescript
 
 sealed abstract class Flow extends Target
 case object Flow extends Flow
+
+sealed abstract class Elm extends Target
+case object Elm extends Elm

--- a/src/main/scala/bridges/Type.scala
+++ b/src/main/scala/bridges/Type.scala
@@ -44,7 +44,7 @@ object Type {
   }
 
   object Struct {
-    def apply(fields: (String, Type) *): Struct =
+    def apply(fields: (String, Type)*): Struct =
       Struct(fields.toList)
   }
 
@@ -54,7 +54,7 @@ object Type {
   }
 
   object Union {
-    def apply(types: Type *): Union =
+    def apply(types: Type*): Union =
       Union(types.toList)
   }
 
@@ -64,7 +64,7 @@ object Type {
   }
 
   object Intersection {
-    def apply(types: Type *): Intersection =
+    def apply(types: Type*): Intersection =
       Intersection(types.toList)
   }
 
@@ -74,9 +74,9 @@ object Type {
   def disc(key: String)(name: String, tpe: Type): Intersection =
     Intersection(Struct(key -> StrLiteral(name)), tpe)
 
-  def discUnion(types: (String, Type) *): Union =
-    discUnion("type")(types : _*)
+  def discUnion(types: (String, Type)*): Union =
+    discUnion("type")(types: _*)
 
-  def discUnion(key: String)(types: (String, Type) *): Union =
+  def discUnion(key: String)(types: (String, Type)*): Union =
     Union(types.map { case (name, tpe) => disc(key)(name, tpe) }.toList)
 }

--- a/src/main/scala/bridges/Type.scala
+++ b/src/main/scala/bridges/Type.scala
@@ -68,15 +68,17 @@ object Type {
       Intersection(types.toList)
   }
 
-  def disc(name: String, tpe: Type): Intersection =
-    disc("type")(name, tpe)
+  def disc(name: String, tpe: Type, fields: Struct): Intersection =
+    disc("type")(name, tpe, fields)
 
-  def disc(key: String)(name: String, tpe: Type): Intersection =
-    Intersection(Struct(key -> StrLiteral(name)), tpe)
+  def disc(key: String)(name: String, tpe: Type, fields: Struct): Intersection =
+    Intersection(Struct(key -> StrLiteral(name), "fields" -> fields), tpe)
 
-  def discUnion(types: (String, Type)*): Union =
+  def discUnion(types: (String, Type, Struct)*): Union =
     discUnion("type")(types: _*)
 
-  def discUnion(key: String)(types: (String, Type)*): Union =
-    Union(types.map { case (name, tpe) => disc(key)(name, tpe) }.toList)
+  def discUnion(key: String)(types: (String, Type, Struct)*): Union =
+    Union(
+      types.map { case (name, tpe, fields) => disc(key)(name, tpe, fields) }.toList
+    )
 }

--- a/src/main/scala/bridges/Type.scala
+++ b/src/main/scala/bridges/Type.scala
@@ -19,16 +19,23 @@ object Type {
   final case class StrLiteral(value: String) extends Str
   final case object Str extends Str
 
+  sealed abstract class Character extends Type with Product with Serializable
+  final case class CharLiteral(value: Char) extends Character
+  final case object Character extends Character
+
   sealed abstract class Num extends Type with Product with Serializable
   final case class NumLiteral(value: Num) extends Num
   final case object Num extends Num
+
+  sealed abstract class Floating extends Type with Product with Serializable
+  final case class FloatingLiteral(value: Floating) extends Floating
+  final case object Floating extends Floating
 
   sealed abstract class Bool extends Type with Product with Serializable
   final case class BoolLiteral(value: Boolean) extends Bool
   final case object Bool extends Bool
 
-  final case object Null extends Type
-
+  final case class Optional(tpe: Type) extends Type
   final case class Array(tpe: Type) extends Type
 
   final case class Struct(fields: List[(String, Type)]) extends Type {

--- a/src/main/scala/bridges/syntax.scala
+++ b/src/main/scala/bridges/syntax.scala
@@ -12,14 +12,19 @@ object syntax {
   def typeName[A](implicit typeable: Typeable[A]): String =
     typeable.describe.takeWhile(_ != '[').mkString
 
-  def declaration[A](implicit typeable: Typeable[A], encoder: Lazy[Encoder[A]]): Declaration =
+  def declaration[A](
+      implicit typeable: Typeable[A],
+      encoder: Lazy[Encoder[A]]
+  ): Declaration =
     Declaration(typeName[A], encoder.value.encode)
 
-  def render[A](decls: List[Declaration])(implicit renderer: Renderer[A]): String =
+  def render[A](
+      decls: List[Declaration]
+  )(implicit renderer: Renderer[A]): String =
     renderer.render(decls)
 
   implicit class StringOps(str: String) {
-    def := [A](tpe: Type): Declaration =
+    def :=[A](tpe: Type): Declaration =
       Declaration(str, tpe)
   }
 

--- a/src/main/scala/bridges/syntax.scala
+++ b/src/main/scala/bridges/syntax.scala
@@ -28,8 +28,8 @@ object syntax {
       Declaration(str, tpe)
   }
 
-  implicit class StringPairOps(a: (String, Type)) {
-    def |(b: (String, Type)): Union =
+  implicit class StringPairOps(a: (String, Type, Struct)) {
+    def |(b: (String, Type, Struct)): Union =
       discUnion(a, b)
   }
 }

--- a/src/main/scala/bridges/syntax.scala
+++ b/src/main/scala/bridges/syntax.scala
@@ -8,8 +8,12 @@ object syntax {
   def encode[A: Encoder]: Type =
     Encoder[A].encode
 
+  // TODO latest Shapeless version adds typeable information of members to case classes, which we don't want. Filtering that out while I discover a better fix
+  def typeName[A](implicit typeable: Typeable[A]): String =
+    typeable.describe.takeWhile(_ != '[').mkString
+
   def declaration[A](implicit typeable: Typeable[A], encoder: Lazy[Encoder[A]]): Declaration =
-    Declaration(typeable.describe, encoder.value.encode)
+    Declaration(typeName[A], encoder.value.encode)
 
   def render[A](decls: List[Declaration])(implicit renderer: Renderer[A]): String =
     renderer.render(decls)

--- a/src/test/scala/bridges/EncoderSpec.scala
+++ b/src/test/scala/bridges/EncoderSpec.scala
@@ -18,13 +18,15 @@ object EncoderSpec {
   final case class Color(red: Int, green: Int, blue: Int)
   sealed abstract class Shape extends Product with Serializable
   final case class Circle(radius: Double, color: Color) extends Shape
-  final case class Rectangle(width: Double, height: Double, color: Color) extends Shape
+  final case class Rectangle(width: Double, height: Double, color: Color)
+      extends Shape
   final case class ShapeGroup(leftShape: Shape, rightShape: Shape) extends Shape
 
   // Recursive structure
   sealed trait Navigation
   final case class NodeList(all: List[Navigation]) extends Navigation
-  final case class Node(name: String, children: List[Navigation]) extends Navigation
+  final case class Node(name: String, children: List[Navigation])
+      extends Navigation
 }
 
 class EncoderSpec extends FreeSpec with Matchers {
@@ -61,7 +63,9 @@ class EncoderSpec extends FreeSpec with Matchers {
     }
 
     "sealed types" in {
-      encode[OneOrOther] should be(discUnion("One" -> Ref("One"), "Other" -> Ref("Other")))
+      encode[OneOrOther] should be(
+        discUnion("One" -> Ref("One"), "Other" -> Ref("Other"))
+      )
     }
 
     "overridden defaults" in {
@@ -69,20 +73,42 @@ class EncoderSpec extends FreeSpec with Matchers {
         Encoder.pure(Str)
 
       encode[One] should be(Str)
-      encode[OneOrOther] should be(discUnion("One" -> Str, "Other" -> Ref("Other")))
+      encode[OneOrOther] should be(
+        discUnion("One" -> Str, "Other" -> Ref("Other"))
+      )
     }
 
     "sealed types with intermediate types and indirect recursion" in {
-      encode[Shape] should be(discUnion("Circle" -> Ref("Circle"), "Rectangle" -> Ref("Rectangle"), "ShapeGroup" -> Ref("ShapeGroup")))
-      encode[Circle] should be(Struct("radius" -> Floating, "color" -> Ref("Color")))
-      encode[Rectangle] should be(Struct("width" -> Floating, "height" -> Floating, "color" -> Ref("Color")))
-      encode[ShapeGroup] should be(Struct("leftShape" ->  Ref("Shape"), "rightShape" -> Ref("Shape")))
+      encode[Shape] should be(
+        discUnion(
+          "Circle" -> Ref("Circle"),
+          "Rectangle" -> Ref("Rectangle"),
+          "ShapeGroup" -> Ref("ShapeGroup")
+        )
+      )
+      encode[Circle] should be(
+        Struct("radius" -> Floating, "color" -> Ref("Color"))
+      )
+      encode[Rectangle] should be(
+        Struct(
+          "width" -> Floating,
+          "height" -> Floating,
+          "color" -> Ref("Color")
+        )
+      )
+      encode[ShapeGroup] should be(
+        Struct("leftShape" -> Ref("Shape"), "rightShape" -> Ref("Shape"))
+      )
     }
 
     "recursive types with direct recursion on same type" in {
-      encode[Navigation] should be(discUnion("Node" -> Ref("Node"), "NodeList" -> Ref("NodeList")))
+      encode[Navigation] should be(
+        discUnion("Node" -> Ref("Node"), "NodeList" -> Ref("NodeList"))
+      )
       encode[NodeList] should be(Struct("all" -> Array(Ref("Navigation"))))
-      encode[Node] should be(Struct("name" -> Str, "children" -> Array(Ref("Navigation"))))
+      encode[Node] should be(
+        Struct("name" -> Str, "children" -> Array(Ref("Navigation")))
+      )
     }
   }
 
@@ -96,7 +122,9 @@ class EncoderSpec extends FreeSpec with Matchers {
     }
 
     "sealed types" in {
-      declaration[OneOrOther] should be("OneOrOther" := discUnion("One" -> Ref("One"), "Other" -> Ref("Other")))
+      declaration[OneOrOther] should be(
+        "OneOrOther" := discUnion("One" -> Ref("One"), "Other" -> Ref("Other"))
+      )
     }
 
     "overridden defaults" in {
@@ -104,7 +132,9 @@ class EncoderSpec extends FreeSpec with Matchers {
         Encoder.pure(Str)
 
       encode[One] should be(Str)
-      declaration[OneOrOther] should be("OneOrOther" := discUnion("One" -> Str, "Other" -> Ref("Other")))
+      declaration[OneOrOther] should be(
+        "OneOrOther" := discUnion("One" -> Str, "Other" -> Ref("Other"))
+      )
     }
   }
 }

--- a/src/test/scala/bridges/EncoderSpec.scala
+++ b/src/test/scala/bridges/EncoderSpec.scala
@@ -35,14 +35,16 @@ class EncoderSpec extends FreeSpec with Matchers {
   "encode[A]" - {
     "primitive types" in {
       encode[String] should be(Str)
+      encode[Char] should be(Character)
       encode[Int] should be(Num)
-      encode[Double] should be(Num)
+      encode[Float] should be(Floating)
+      encode[Double] should be(Floating)
       encode[Boolean] should be(Bool)
     }
 
     "options" in {
-      encode[Option[String]] should be(Str | Null)
-      encode[Option[Int]] should be(Num | Null)
+      encode[Option[String]] should be(Optional(Str))
+      encode[Option[Int]] should be(Optional(Num))
     }
 
     "sequences" in {
@@ -72,8 +74,8 @@ class EncoderSpec extends FreeSpec with Matchers {
 
     "sealed types with intermediate types and indirect recursion" in {
       encode[Shape] should be(discUnion("Circle" -> Ref("Circle"), "Rectangle" -> Ref("Rectangle"), "ShapeGroup" -> Ref("ShapeGroup")))
-      encode[Circle] should be(Struct("radius" -> Num, "color" -> Ref("Color")))
-      encode[Rectangle] should be(Struct("width" -> Num, "height" -> Num, "color" -> Ref("Color")))
+      encode[Circle] should be(Struct("radius" -> Floating, "color" -> Ref("Color")))
+      encode[Rectangle] should be(Struct("width" -> Floating, "height" -> Floating, "color" -> Ref("Color")))
       encode[ShapeGroup] should be(Struct("leftShape" ->  Ref("Shape"), "rightShape" -> Ref("Shape")))
     }
 

--- a/src/test/scala/bridges/RendererSpec.scala
+++ b/src/test/scala/bridges/RendererSpec.scala
@@ -12,7 +12,11 @@ object RendererSpec {
   case class Rectangle(width: Double, height: Double, color: Color) extends Shape
   case class Circle(radius: Double, color: Color) extends Shape
 
-  val customDeclaration =
+  final case class Alpha(name: String, char: Char, bool: Boolean)
+  final case class ArrayClass(aList: List[String], optField: Option[Float])
+  final case class Numeric(double: Double, float: Float, int: Int)
+
+  val customDeclaration: Declaration =
     "Message" := Type.discUnion("level")(
       "error"   -> Type.Ref("ErrorMessage"),
       "warning" -> Type.Ref("WarningMessage")
@@ -31,6 +35,9 @@ class RendererSpec extends FreeSpec with Matchers {
           declaration[Circle],
           declaration[Rectangle],
           declaration[Shape],
+          declaration[Alpha],
+          declaration[ArrayClass],
+          declaration[Numeric],
           customDeclaration
         ))
 
@@ -44,6 +51,12 @@ class RendererSpec extends FreeSpec with Matchers {
 
         export type Shape = (({ type: "Circle" } & Circle) | ({ type: "Rectangle" } & Rectangle));
 
+        export type Alpha = { name: string, char: string, bool: boolean };
+
+        export type ArrayClass = { aList: Array<string>, optField: (number | null) };
+
+        export type Numeric = { double: number, float: number, int: number };
+
         export type Message = (({ level: "error" } & ErrorMessage) | ({ level: "warning" } & WarningMessage));
         """
 
@@ -56,7 +69,10 @@ class RendererSpec extends FreeSpec with Matchers {
           declaration[Color],
           declaration[Circle],
           declaration[Rectangle],
-          declaration[Shape]
+          declaration[Shape],
+          declaration[Alpha],
+          declaration[ArrayClass],
+          declaration[Numeric]
         ))
 
       val expected: String =
@@ -68,6 +84,44 @@ class RendererSpec extends FreeSpec with Matchers {
         export type Rectangle = { width: number, height: number, color: Color };
 
         export type Shape = (({ type: "Circle" } & Circle) | ({ type: "Rectangle" } & Rectangle));
+
+        export type Alpha = { name: string, char: string, bool: boolean };
+
+        export type ArrayClass = { aList: Array<string>, optField: (number | null) };
+
+        export type Numeric = { double: number, float: number, int: number };
+        """
+
+      actual should be(expected)
+    }
+
+    "elm" in {
+      val actual: String =
+        render[Elm](List(
+          declaration[Color],
+          declaration[Circle],
+          declaration[Rectangle],
+          declaration[Shape],
+          declaration[Alpha],
+          declaration[ArrayClass],
+          declaration[Numeric]
+        ))
+
+      val expected: String =
+        i"""
+        type alias Color = { red: Int, green: Int, blue: Int }
+
+        type alias Circle = { radius: Float, color: Color }
+
+        type alias Rectangle = { width: Float, height: Float, color: Color }
+
+        type Shape = Circle | Rectangle
+
+        type alias Alpha = { name: String, char: Char, bool: Bool }
+
+        type alias ArrayClass = { aList: List String, optField: Maybe Float }
+
+        type alias Numeric = { double: Float, float: Float, int: Int }
         """
 
       actual should be(expected)

--- a/src/test/scala/bridges/RendererSpec.scala
+++ b/src/test/scala/bridges/RendererSpec.scala
@@ -9,7 +9,8 @@ object RendererSpec {
   final case class Color(red: Int, green: Int, blue: Int)
 
   sealed abstract class Shape extends Product with Serializable
-  case class Rectangle(width: Double, height: Double, color: Color) extends Shape
+  case class Rectangle(width: Double, height: Double, color: Color)
+      extends Shape
   case class Circle(radius: Double, color: Color) extends Shape
 
   final case class Alpha(name: String, char: Char, bool: Boolean)
@@ -18,7 +19,7 @@ object RendererSpec {
 
   val customDeclaration: Declaration =
     "Message" := Type.discUnion("level")(
-      "error"   -> Type.Ref("ErrorMessage"),
+      "error" -> Type.Ref("ErrorMessage"),
       "warning" -> Type.Ref("WarningMessage")
     )
 }
@@ -30,16 +31,18 @@ class RendererSpec extends FreeSpec with Matchers {
   "render" - {
     "typescript" in {
       val actual: String =
-        render[Typescript](List(
-          declaration[Color],
-          declaration[Circle],
-          declaration[Rectangle],
-          declaration[Shape],
-          declaration[Alpha],
-          declaration[ArrayClass],
-          declaration[Numeric],
-          customDeclaration
-        ))
+        render[Typescript](
+          List(
+            declaration[Color],
+            declaration[Circle],
+            declaration[Rectangle],
+            declaration[Shape],
+            declaration[Alpha],
+            declaration[ArrayClass],
+            declaration[Numeric],
+            customDeclaration
+          )
+        )
 
       val expected: String =
         i"""
@@ -65,15 +68,17 @@ class RendererSpec extends FreeSpec with Matchers {
 
     "flow" in {
       val actual: String =
-        render[Flow](List(
-          declaration[Color],
-          declaration[Circle],
-          declaration[Rectangle],
-          declaration[Shape],
-          declaration[Alpha],
-          declaration[ArrayClass],
-          declaration[Numeric]
-        ))
+        render[Flow](
+          List(
+            declaration[Color],
+            declaration[Circle],
+            declaration[Rectangle],
+            declaration[Shape],
+            declaration[Alpha],
+            declaration[ArrayClass],
+            declaration[Numeric]
+          )
+        )
 
       val expected: String =
         i"""
@@ -97,15 +102,17 @@ class RendererSpec extends FreeSpec with Matchers {
 
     "elm" in {
       val actual: String =
-        render[Elm](List(
-          declaration[Color],
-          declaration[Circle],
-          declaration[Rectangle],
-          declaration[Shape],
-          declaration[Alpha],
-          declaration[ArrayClass],
-          declaration[Numeric]
-        ))
+        render[Elm](
+          List(
+            declaration[Color],
+            declaration[Circle],
+            declaration[Rectangle],
+            declaration[Shape],
+            declaration[Alpha],
+            declaration[ArrayClass],
+            declaration[Numeric]
+          )
+        )
 
       val expected: String =
         i"""


### PR DESCRIPTION
WIP - I want to add more stuff (json decoder/encoder for Elm, tests), but right now this should generate valid Elm code from the intermediate language

I've had to expand the language used by the encoder to tackle differences between Elm and Typescrypt, regarding strings/chars/floats/union types. I run the typescrypt code in an online validator and it seemed to be right. Same for Elm code.

Feedback welcome so I can polish this to an acceptable standard and this can be published to maven repo so we can use it for our project 😁 
