### PR TITLE
Fix #11 More convenient support for Refined

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,45 +111,19 @@ you need to do the following:
 
 If you are interested in this library
 you are most likely using [Refined](https://github.com/fthomas/refined).
-If you do, you will notice that any Refined type
-you use in your case classes fails to derive properly,
-usually resulting in missing fields.
 
-The solution for this issue is to use `implicits` that define conversions
-from your refined type to a more generic version.
-For example, from a refined `String` to a generic `String`.
-You can see an example in tests that use class `ClassWithRefinedType`,
-created in purpose to showcase this issue.
+We have provided a default encoder for refined types. It will defaults
+to the basic type associated with the refined type. For example:
 
-The relevant fragments of code are:
+* For `Int Refined Greater[W.`6`.T]` we treat the type as an `Int`
+* For `String Refined Size[ClosedOpen[W.`1`.T, W.`100`.T]]` we treat the type as a `String`
+* etc
 
-~~~scala
-type ShortStringRefinementType = Size[ClosedOpen[W.`1`.T, W.`100`.T]]
-type ShortString = String Refined ShortStringRefinementType
+This should cover most (if not all) use cases of refined types when converting to other languages.
+You can still override the default encoder with your own higher-precedence encoder. 
 
-final case class ClassWithRefinedType(name: ShortString)
+You can see an example of this in tests for class `ClassWithRefinedType`.
 
-"ClassWithRefinedType" in {
-  import eu.timepit.refined._
-
-  implicit val refinedTypeEncoder: BasicEncoder[ShortString] =
-    Encoder.pure(Str)
-
-  implicit val refinedTypeTypeable: Typeable[ShortString] =
-    new Typeable[ShortString] {
-      def cast(t: Any): Option[ShortString] =
-        if (t != null && t.isInstanceOf[String])
-          refineV[ShortStringRefinementType](t.asInstanceOf[String]).toOption
-        else None
-
-      def describe: String =
-        "ShortString"
-    }
-
-  render[Elm](declaration[ClassWithRefinedType]) shouldBe
-    """type alias ClassWithRefinedType = { name: String }"""
-}
-~~~
 
 ## Developing
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,12 +12,15 @@ scalacOptions ++= Seq(
   "-Ypartial-unification"
 )
 
+val refinedVersion = "0.9.0"
+
 libraryDependencies ++= Seq(
-  "com.chuusai"       %% "shapeless"     % "2.3.3",
-  "com.davegurnell"   %% "unindent"      % "1.1.0" exclude("org.typelevel", "scala-library"),
-  "org.apache.commons" % "commons-lang3" % "3.5",
-  "org.scalatest"     %% "scalatest"     % "3.0.5" % Test,
-  "eu.timepit"        %% "refined"       % "0.9.0" % Test
+  "com.chuusai"       %% "shapeless"          % "2.3.3",
+  "com.davegurnell"   %% "unindent"           % "1.1.0" exclude("org.typelevel", "scala-library"),
+  "org.apache.commons" % "commons-lang3"      % "3.5",
+  "org.scalatest"     %% "scalatest"          % "3.0.5" % Test,
+  "eu.timepit"        %% "refined"            % refinedVersion % Provided,
+  "eu.timepit"        %% "refined-shapeless"  % refinedVersion % Provided
 )
 
 // Versioning

--- a/src/main/scala/bridges/core/Encoder.scala
+++ b/src/main/scala/bridges/core/Encoder.scala
@@ -1,6 +1,7 @@
 package bridges.core
 
 import bridges.syntax.typeName
+import eu.timepit.refined.api._
 import scala.language.higherKinds
 import shapeless._
 import shapeless.labelled.FieldType
@@ -60,6 +61,10 @@ trait EncoderInstances2 extends EncoderInstances1 {
       encoder: BasicEncoder[B]
   ): BasicEncoder[A] =
     pure(encoder.encode)
+
+  implicit def refinedEncoder[A, B](implicit enc: BasicEncoder[A]): BasicEncoder[Refined[A, B]] =
+    Encoder.pure(enc.encode)
+
 }
 
 trait EncoderInstances1 extends EncoderInstances0 {

--- a/src/main/scala/bridges/syntax.scala
+++ b/src/main/scala/bridges/syntax.scala
@@ -2,9 +2,9 @@ package bridges
 
 import bridges.core._
 import shapeless.{ Lazy, Typeable }
+import Type._
 
 object syntax {
-  import Type._
 
   def encode[A: Encoder]: Type =
     Encoder[A].encode

--- a/src/test/scala/bridges/SampleTypes.scala
+++ b/src/test/scala/bridges/SampleTypes.scala
@@ -8,11 +8,14 @@ import bridges.syntax._
 import eu.timepit.refined.W
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.collection.Size
+import eu.timepit.refined.generic.Equal
+import eu.timepit.refined.numeric.Greater
 import eu.timepit.refined.numeric.Interval.ClosedOpen
 
 object SampleTypes {
-  type ShortStringRefinementType = Size[ClosedOpen[W.`1`.T, W.`100`.T]]
-  type ShortString               = String Refined ShortStringRefinementType
+  type RefinedString = String Refined Size[ClosedOpen[W.`1`.T, W.`100`.T]]
+  type RefinedInt    = Int Refined Greater[W.`6`.T]
+  type RefinedChar   = Char Refined Equal[W.`'3'`.T]
 
   // Sample product
   case class Pair(a: String, b: Int)
@@ -79,5 +82,5 @@ object SampleTypes {
       ("warning", Type.Ref("WarningMessage"), Struct(Nil))
     )
 
-  final case class ClassWithRefinedType(name: ShortString)
+  final case class ClassWithRefinedType(name: RefinedString)
 }

--- a/src/test/scala/bridges/core/EncoderSpec.scala
+++ b/src/test/scala/bridges/core/EncoderSpec.scala
@@ -4,7 +4,6 @@ import bridges.SampleTypes._
 import bridges.core.Type._
 import bridges.syntax._
 import org.scalatest._
-import shapeless.Typeable
 
 class EncoderSpec extends FreeSpec with Matchers {
   "encode[A]" - {
@@ -175,10 +174,10 @@ class EncoderSpec extends FreeSpec with Matchers {
       )
     }
 
-    "class with refined type" in {
-      implicit val refinedTypeEncoder: BasicEncoder[ShortString] =
-        Encoder.pure(Str)
-
+    "refined types and class containing them" in {
+      encode[RefinedString] should be(Str)
+      encode[RefinedInt] should be(Num)
+      encode[RefinedChar] should be(Character)
       encode[ClassWithRefinedType] should be(Struct("name" -> Str))
     }
 
@@ -224,19 +223,7 @@ class EncoderSpec extends FreeSpec with Matchers {
     }
 
     "class with refined type" in {
-      import eu.timepit.refined._
-
-      implicit val refinedTypeEncoder: BasicEncoder[ShortString] =
-        Encoder.pure(Str)
-
-      implicit val refinedTypeTypeable: Typeable[ShortString] =
-        new Typeable[ShortString] {
-          def cast(t: Any): Option[ShortString] =
-            if (t != null && t.isInstanceOf[String])
-              refineV[ShortStringRefinementType](t.asInstanceOf[String]).toOption
-            else None
-          def describe: String = "ShortString"
-        }
+      import eu.timepit.refined.shapeless.typeable._
 
       declaration[ClassWithRefinedType] should be(
         "ClassWithRefinedType" := Struct("name" -> Str)

--- a/src/test/scala/bridges/elm/ElmRendererSpec.scala
+++ b/src/test/scala/bridges/elm/ElmRendererSpec.scala
@@ -5,7 +5,6 @@ import bridges.core.Type._
 import bridges.core._
 import bridges.syntax._
 import org.scalatest._
-import shapeless.Typeable
 
 class ElmRendererSpec extends FreeSpec with Matchers {
   "Color" in {
@@ -69,19 +68,7 @@ class ElmRendererSpec extends FreeSpec with Matchers {
   }
 
   "ClassWithRefinedType" in {
-    import eu.timepit.refined._
-
-    implicit val refinedTypeEncoder: BasicEncoder[ShortString] =
-      Encoder.pure(Str)
-
-    implicit val refinedTypeTypeable: Typeable[ShortString] =
-      new Typeable[ShortString] {
-        def cast(t: Any): Option[ShortString] =
-          if (t != null && t.isInstanceOf[String])
-            refineV[ShortStringRefinementType](t.asInstanceOf[String]).toOption
-          else None
-        def describe: String = "ShortString"
-      }
+    import eu.timepit.refined.shapeless.typeable._
 
     Elm.render(declaration[ClassWithRefinedType]) shouldBe """type alias ClassWithRefinedType = { name: String }"""
   }


### PR DESCRIPTION
This should solve the refined issues. Only requirement, for `declaration` is to add an import from `refined-shapeless` so we can get the right `Typeable`.