### PR TITLE
Feature/self recursive types

### DIFF
--- a/src/main/scala/bridges/core/DeclF.scala
+++ b/src/main/scala/bridges/core/DeclF.scala
@@ -1,7 +1,5 @@
 package bridges.core
 
-import shapeless.{ Lazy, Typeable }
-
 /** A named declaration. Either top-level or a field in a sum, product, or struct.
   *
   * We define type aliases for DeclF in

--- a/src/main/scala/bridges/core/Encoder.scala
+++ b/src/main/scala/bridges/core/Encoder.scala
@@ -3,6 +3,7 @@ package bridges.core
 import bridges.core.syntax._
 import eu.timepit.refined.api._
 import scala.language.higherKinds
+import scala.reflect.runtime.universe.WeakTypeTag
 import shapeless._
 import shapeless.labelled.FieldType
 
@@ -110,10 +111,10 @@ trait EncoderInstances0 extends EncoderConstructors {
 
   implicit def genericBasicEncoder[A](
       implicit
-      typeable: Typeable[A],
-      low: LowPriority
+      low: LowPriority,
+      tpeTag: WeakTypeTag[A]
   ): BasicEncoder[A] =
-    pure(Ref(typeName[A]))
+    pure(Ref(getCleanTagName[A]))
 }
 
 trait EncoderConstructors {

--- a/src/main/scala/bridges/core/syntax.scala
+++ b/src/main/scala/bridges/core/syntax.scala
@@ -1,18 +1,27 @@
 package bridges.core
 
-import shapeless.{ Lazy, Typeable }
+import shapeless.Lazy
+import scala.reflect.runtime.universe.WeakTypeTag
 
 object syntax extends RenamableSyntax {
   import Type._
 
+  // NOTE: we can't use `shapeless.Typeable` in here as it breaks the code for recursive types like
+  //   final case class Recursive(head: Int, tail: Option[Recursive])
+  //
+  // The only solution I found is to use a `WeakTypeTag` from scala runtime, which seems to
+  // manage the recursivity OK. We just need some 'hacky' method to clean the output
+  def getCleanTagName[A](implicit tpeTag: WeakTypeTag[A]): String = {
+    // dirtyName will have form of: TypeTag[bridges.SampleTypes.Recurring]
+    val dirtyName = tpeTag.toString()
+    dirtyName.split('.').last.dropRight(1)
+  }
+
   def encode[A: Encoder]: Type =
     Encoder[A].encode
 
-  def typeName[A](implicit typeable: Typeable[A]): String =
-    typeable.describe.takeWhile(c ⇒ c != '[' && c != '.').mkString
-
-  def decl[A](implicit typeable: Typeable[A], encoder: Lazy[Encoder[A]]): Decl =
-    DeclF(typeName[A], encoder.value.encode)
+  def decl[A](implicit tpeTag: WeakTypeTag[A], encoder: Lazy[Encoder[A]]): Decl =
+    DeclF(getCleanTagName[A], encoder.value.encode)
 
   def prod(fields: Decl*): Prod =
     Prod(fields.toList)

--- a/src/main/scala/bridges/flow/syntax.scala
+++ b/src/main/scala/bridges/flow/syntax.scala
@@ -1,7 +1,9 @@
 package bridges.flow
 
 import bridges.core._
-import shapeless.{ Lazy, Typeable }
+import bridges.core.syntax.getCleanTagName
+import shapeless.Lazy
+import scala.reflect.runtime.universe.WeakTypeTag
 
 object syntax extends RenamableSyntax {
   import FlowType._
@@ -9,11 +11,8 @@ object syntax extends RenamableSyntax {
   def encode[A: Encoder]: FlowType =
     from(Encoder[A].encode)
 
-  def typeName[A](implicit typeable: Typeable[A]): String =
-    typeable.describe.takeWhile(c ⇒ c != '[' && c != '.').mkString
-
-  def decl[A](implicit typeable: Typeable[A], encoder: Lazy[Encoder[A]]): FlowDecl =
-    DeclF(typeName[A], encoder.value.encode).map(FlowType.from)
+  def decl[A](implicit tpeTag: WeakTypeTag[A], encoder: Lazy[Encoder[A]]): FlowDecl =
+    DeclF(getCleanTagName[A], encoder.value.encode).map(FlowType.from)
 
   def struct(fields: FlowDecl*): FlowType =
     Struct(fields.toList)

--- a/src/main/scala/bridges/typescript/syntax.scala
+++ b/src/main/scala/bridges/typescript/syntax.scala
@@ -1,7 +1,9 @@
 package bridges.typescript
 
 import bridges.core.{ DeclF, Encoder, RenamableSyntax }
-import shapeless.{ Lazy, Typeable }
+import bridges.core.syntax.getCleanTagName
+import shapeless.Lazy
+import scala.reflect.runtime.universe.WeakTypeTag
 
 object syntax extends RenamableSyntax {
   import TsType._
@@ -9,11 +11,8 @@ object syntax extends RenamableSyntax {
   def encode[A: Encoder]: TsType =
     from(Encoder[A].encode)
 
-  def typeName[A](implicit typeable: Typeable[A]): String =
-    typeable.describe.takeWhile(c ⇒ c != '[' && c != '.').mkString
-
-  def decl[A](implicit typeable: Typeable[A], encoder: Lazy[Encoder[A]]): TsDecl =
-    DeclF(typeName[A], encoder.value.encode).map(TsType.from)
+  def decl[A](implicit tpeTag: WeakTypeTag[A], encoder: Lazy[Encoder[A]]): TsDecl =
+    DeclF(getCleanTagName[A], encoder.value.encode).map(TsType.from)
 
   def struct(fields: TsDecl*): Struct =
     Struct(fields.toList)

--- a/src/test/scala/bridges/SampleTypes.scala
+++ b/src/test/scala/bridges/SampleTypes.scala
@@ -73,6 +73,10 @@ object SampleTypes {
   final case class OptionOne(value: Int)     extends TypeTwo
   final case class OptionTwo(value: TypeOne) extends TypeTwo
 
+  // Self-recursive type
+  final case class Recursive(head: Int, tail: Option[Recursive])
+  final case class Recursive2(head: Int, tail: List[Recursive2])
+
   sealed trait ObjectsOnly
   final case object ObjectOne extends ObjectsOnly
   final case object ObjectTwo extends ObjectsOnly

--- a/src/test/scala/bridges/core/EncoderSpec.scala
+++ b/src/test/scala/bridges/core/EncoderSpec.scala
@@ -4,6 +4,7 @@ import bridges.SampleTypes._
 import bridges.core.Type._
 import bridges.core.syntax._
 import org.scalatest._
+import shapeless.{ Generic, LabelledGeneric, TypeCase, Typeable }
 
 class EncoderSpec extends FreeSpec with Matchers {
   "encode[A]" - {
@@ -208,8 +209,24 @@ class EncoderSpec extends FreeSpec with Matchers {
 
       encode[TypeTwo] should be(
         sum(
-         "OptionOne" := prod("value" := Intr),
-         "OptionTwo" := prod("value" := Ref("TypeOne"))
+          "OptionOne" := prod("value" := Intr),
+          "OptionTwo" := prod("value" := Ref("TypeOne"))
+        )
+      )
+    }
+
+    "self-recursive type" in {
+      encode[Recursive] should be(
+        prod(
+          "head" := Intr,
+          "tail" := Opt(Ref("Recursive"))
+        )
+      )
+
+      encode[Recursive2] should be(
+        prod(
+          "head" := Intr,
+          "tail" := Arr(Ref("Recursive2"))
         )
       )
     }

--- a/src/test/scala/bridges/core/EncoderSpec.scala
+++ b/src/test/scala/bridges/core/EncoderSpec.scala
@@ -198,6 +198,22 @@ class EncoderSpec extends FreeSpec with Matchers {
       )
     }
 
+    "mutually recursive types" in {
+      encode[TypeOne] should be(
+        prod(
+          "name" := Str,
+          "values" := Arr(Ref("TypeTwo"))
+        )
+      )
+
+      encode[TypeTwo] should be(
+        sum(
+         "OptionOne" := prod("value" := Intr),
+         "OptionTwo" := prod("value" := Ref("TypeOne"))
+        )
+      )
+    }
+
     "pure objects ADT" in {
       encode[ObjectsOnly] should be(
         sum(

--- a/src/test/scala/bridges/elm/ElmJsonDecoderSpec.scala
+++ b/src/test/scala/bridges/elm/ElmJsonDecoderSpec.scala
@@ -8,36 +8,33 @@ import org.scalatest._
 import unindent._
 
 class ElmJsonDecoderSpec extends FreeSpec with Matchers {
-  "decoder" - {
-    "elm" - {
-
-      "Color" in {
-        Elm.decoder(decl[Color]) shouldBe
-        i"""
+  "Color" in {
+    Elm.decoder(decl[Color]) shouldBe
+    i"""
            decoderColor : Decode.Decoder Color
            decoderColor = decode Color |> required "red" Decode.int |> required "green" Decode.int |> required "blue" Decode.int
            """
-      }
+  }
 
-      "Circle" in {
-        Elm.decoder(decl[Circle]) shouldBe
-        i"""
+  "Circle" in {
+    Elm.decoder(decl[Circle]) shouldBe
+    i"""
            decoderCircle : Decode.Decoder Circle
            decoderCircle = decode Circle |> required "radius" Decode.float |> required "color" (Decode.lazy (\\_ -> decoderColor))
            """
-      }
+  }
 
-      "Rectangle" in {
-        Elm.decoder(decl[Rectangle]) shouldBe
-        i"""
+  "Rectangle" in {
+    Elm.decoder(decl[Rectangle]) shouldBe
+    i"""
            decoderRectangle : Decode.Decoder Rectangle
            decoderRectangle = decode Rectangle |> required "width" Decode.float |> required "height" Decode.float |> required "color" (Decode.lazy (\\_ -> decoderColor))
            """
-      }
+  }
 
-      "Shape" in {
-        Elm.decoder(decl[Shape]) shouldBe
-        i"""
+  "Shape" in {
+    Elm.decoder(decl[Shape]) shouldBe
+    i"""
            decoderShape : Decode.Decoder Shape
            decoderShape = Decode.field "type" Decode.string |> Decode.andThen decoderShapeTpe
 
@@ -49,35 +46,35 @@ class ElmJsonDecoderSpec extends FreeSpec with Matchers {
                  "ShapeGroup" -> decode ShapeGroup |> required "leftShape" (Decode.lazy (\\_ -> decoderShape)) |> required "rightShape" (Decode.lazy (\\_ -> decoderShape))
                  _ -> Decode.fail ("Unexpected type for Shape: " ++ tpe)
            """
-      }
+  }
 
-      "Alpha" in {
-        Elm.decoder(decl[Alpha]) shouldBe
-        i"""
+  "Alpha" in {
+    Elm.decoder(decl[Alpha]) shouldBe
+    i"""
            decoderAlpha : Decode.Decoder Alpha
            decoderAlpha = decode Alpha |> required "name" Decode.string |> required "char" Decode.string |> required "bool" Decode.bool
            """
-      }
+  }
 
-      "ArrayClass" in {
-        Elm.decoder(decl[ArrayClass]) shouldBe
-        i"""
+  "ArrayClass" in {
+    Elm.decoder(decl[ArrayClass]) shouldBe
+    i"""
            decoderArrayClass : Decode.Decoder ArrayClass
            decoderArrayClass = decode ArrayClass |> required "aList" (Decode.list Decode.string) |> optional "optField" (Decode.maybe Decode.float) Nothing
            """
-      }
+  }
 
-      "Numeric" in {
-        Elm.decoder(decl[Numeric]) shouldBe
-        i"""
+  "Numeric" in {
+    Elm.decoder(decl[Numeric]) shouldBe
+    i"""
            decoderNumeric : Decode.Decoder Numeric
            decoderNumeric = decode Numeric |> required "double" Decode.float |> required "float" Decode.float |> required "int" Decode.int
            """
-      }
+  }
 
-      "ClassOrObject" in {
-        Elm.decoder(decl[ClassOrObject]) shouldBe
-        i"""
+  "ClassOrObject" in {
+    Elm.decoder(decl[ClassOrObject]) shouldBe
+    i"""
            decoderClassOrObject : Decode.Decoder ClassOrObject
            decoderClassOrObject = Decode.field "type" Decode.string |> Decode.andThen decoderClassOrObjectTpe
 
@@ -88,11 +85,11 @@ class ElmJsonDecoderSpec extends FreeSpec with Matchers {
                  "MyObject" -> Decode.succeed MyObject
                  _ -> Decode.fail ("Unexpected type for ClassOrObject: " ++ tpe)
            """
-      }
+  }
 
-      "Navigation" in {
-        Elm.decoder(decl[Navigation]) shouldBe
-        i"""
+  "Navigation" in {
+    Elm.decoder(decl[Navigation]) shouldBe
+    i"""
            decoderNavigation : Decode.Decoder Navigation
            decoderNavigation = Decode.field "type" Decode.string |> Decode.andThen decoderNavigationTpe
 
@@ -103,19 +100,19 @@ class ElmJsonDecoderSpec extends FreeSpec with Matchers {
                  "NodeList" -> decode NodeList |> required "all" (Decode.list (Decode.lazy (\\_ -> decoderNavigation)))
                  _ -> Decode.fail ("Unexpected type for Navigation: " ++ tpe)
            """
-      }
+  }
 
-      "ExternalReferences" in {
-        Elm.decoder(decl[ExternalReferences]) shouldBe
-        i"""
+  "ExternalReferences" in {
+    Elm.decoder(decl[ExternalReferences]) shouldBe
+    i"""
            decoderExternalReferences : Decode.Decoder ExternalReferences
            decoderExternalReferences = decode ExternalReferences |> required "color" (Decode.lazy (\\_ -> decoderColor)) |> required "nav" (Decode.lazy (\\_ -> decoderNavigation))
            """
-      }
+  }
 
-      "TypeOne and TypeTwo" in {
-        Elm.decoder(List(decl[TypeOne], decl[TypeTwo]), Map.empty[Ref, TypeReplacement]) shouldBe
-        i"""
+  "TypeOne and TypeTwo" in {
+    Elm.decoder(List(decl[TypeOne], decl[TypeTwo]), Map.empty[Ref, TypeReplacement]) shouldBe
+    i"""
            decoderTypeOne : Decode.Decoder TypeOne
            decoderTypeOne = decode TypeOne |> required "name" Decode.string |> required "values" (Decode.list (Decode.lazy (\\_ -> decoderTypeTwo)))
 
@@ -129,85 +126,101 @@ class ElmJsonDecoderSpec extends FreeSpec with Matchers {
                  "OptionTwo" -> decode OptionTwo |> required "value" (Decode.lazy (\\_ -> decoderTypeOne))
                  _ -> Decode.fail ("Unexpected type for TypeTwo: " ++ tpe)
            """
-      }
+  }
 
-      "ClassUUID" - {
-        "by default we treat UUID as a normal type we created" in {
-          // this is the case when we don't import any Elm specific UUID library and we will create our own UUID type there
+  "ClassUUID" - {
+    "by default we treat UUID as a normal type we created" in {
+      // this is the case when we don't import any Elm specific UUID library and we will create our own UUID type there
 
-          Elm.decoder(decl[ClassUUID]) shouldBe
-          i"""
+      Elm.decoder(decl[ClassUUID]) shouldBe
+      i"""
            decoderClassUUID : Decode.Decoder ClassUUID
            decoderClassUUID = decode ClassUUID |> required "a" (Decode.lazy (\\_ -> decoderUUID))
            """
-        }
+    }
 
-        "we can provide a map to substitute UUID decoding with a custom decoding logic" in {
-          // this is the case when we import Elm specific UUID types we want to use in our decoder, but Scala can't know about them without extra hints
-          val customTypeReplacements: Map[Ref, TypeReplacement] = Map(
-            Ref("UUID") → TypeReplacement("Uuid", "import Uuid exposing (Uuid)", "Uuid.decoder", "Uuid.encode")
-          )
+    "we can provide a map to substitute UUID decoding with a custom decoding logic" in {
+      // this is the case when we import Elm specific UUID types we want to use in our decoder, but Scala can't know about them without extra hints
+      val customTypeReplacements: Map[Ref, TypeReplacement] = Map(
+        Ref("UUID") → TypeReplacement("Uuid", "import Uuid exposing (Uuid)", "Uuid.decoder", "Uuid.encode")
+      )
 
-          Elm.decoder(decl[ClassUUID], customTypeReplacements) shouldBe
-          i"""
+      Elm.decoder(decl[ClassUUID], customTypeReplacements) shouldBe
+      i"""
            decoderClassUUID : Decode.Decoder ClassUUID
            decoderClassUUID = decode ClassUUID |> required "a" Uuid.decoder
            """
-        }
+    }
 
-        "we can override the Encoder so we treat UUID as another basic type, like String, and decode it accordingly" in {
-          // probably not recommended, better to use a mapping as in other tests, but it is supported
-          implicit val uuidEncoder: BasicEncoder[java.util.UUID] =
-            Encoder.pure(Str)
+    "we can override the Encoder so we treat UUID as another basic type, like String, and decode it accordingly" in {
+      // probably not recommended, better to use a mapping as in other tests, but it is supported
+      implicit val uuidEncoder: BasicEncoder[java.util.UUID] =
+        Encoder.pure(Str)
 
-          Elm.decoder(decl[ClassUUID]) shouldBe
-          i"""
+      Elm.decoder(decl[ClassUUID]) shouldBe
+      i"""
            decoderClassUUID : Decode.Decoder ClassUUID
            decoderClassUUID = decode ClassUUID |> required "a" Decode.string
            """
-        }
-      }
+    }
+  }
 
-      "ClassDate" - {
-        "by default we treat Date as a normal type we created" in {
-          // this is the case when we don't import any Elm specific Date library and we will create our own Date type there
+  "ClassDate" - {
+    "by default we treat Date as a normal type we created" in {
+      // this is the case when we don't import any Elm specific Date library and we will create our own Date type there
 
-          Elm.decoder(decl[ClassDate]) shouldBe
-          i"""
+      Elm.decoder(decl[ClassDate]) shouldBe
+      i"""
            decoderClassDate : Decode.Decoder ClassDate
            decoderClassDate = decode ClassDate |> required "a" (Decode.lazy (\\_ -> decoderDate))
            """
-        }
+    }
 
-        "we can provide a map to substitute Date decoding with a custom decoding logic" in {
-          // this is the case when we import Elm specific UUID types we want to use in our decoder, but Scala can't know about them without extra hints
-          val customTypeReplacements: Map[Ref, TypeReplacement] = Map(
-            Ref("Date") → TypeReplacement("Date", "import Date exposing (Date)", "Date.decoder", "Date.encode")
-          )
+    "we can provide a map to substitute Date decoding with a custom decoding logic" in {
+      // this is the case when we import Elm specific UUID types we want to use in our decoder, but Scala can't know about them without extra hints
+      val customTypeReplacements: Map[Ref, TypeReplacement] = Map(
+        Ref("Date") → TypeReplacement("Date", "import Date exposing (Date)", "Date.decoder", "Date.encode")
+      )
 
-          Elm.decoder(decl[ClassDate], customTypeReplacements) shouldBe
-          i"""
+      Elm.decoder(decl[ClassDate], customTypeReplacements) shouldBe
+      i"""
            decoderClassDate : Decode.Decoder ClassDate
            decoderClassDate = decode ClassDate |> required "a" Date.decoder
            """
-        }
+    }
 
-        "we can override the Encoder so we treat Date as another basic type, like String, and decode it accordingly" in {
-          // probably not recommended, better to use a mapping as in other tests, but it is supported
-          implicit val dateEncoder: BasicEncoder[java.util.Date] =
-            Encoder.pure(Str)
+    "we can override the Encoder so we treat Date as another basic type, like String, and decode it accordingly" in {
+      // probably not recommended, better to use a mapping as in other tests, but it is supported
+      implicit val dateEncoder: BasicEncoder[java.util.Date] =
+        Encoder.pure(Str)
 
-          Elm.decoder(decl[ClassDate]) shouldBe
-          i"""
+      Elm.decoder(decl[ClassDate]) shouldBe
+      i"""
            decoderClassDate : Decode.Decoder ClassDate
            decoderClassDate = decode ClassDate |> required "a" Decode.string
            """
-        }
-      }
+    }
+  }
 
-      "ObjectsOnly" in {
-        Elm.decoder(decl[ObjectsOnly]) shouldBe
-        i"""
+  "Recursive" in {
+    Elm.decoder(decl[Recursive]) shouldBe
+    i"""
+           decoderRecursive : Decode.Decoder Recursive
+           decoderRecursive = decode Recursive |> required "head" Decode.int |> optional "tail" (Decode.maybe (Decode.lazy (\\_ -> decoderRecursive))) Nothing
+           """
+  }
+
+  "Recursive2" in {
+    Elm.decoder(decl[Recursive2]) shouldBe
+    i"""
+           decoderRecursive2 : Decode.Decoder Recursive2
+           decoderRecursive2 = decode Recursive2 |> required "head" Decode.int |> required "tail" (Decode.list (Decode.lazy (\\_ -> decoderRecursive2)))
+           """
+  }
+
+  "ObjectsOnly" in {
+    Elm.decoder(decl[ObjectsOnly]) shouldBe
+    i"""
            decoderObjectsOnly : Decode.Decoder ObjectsOnly
            decoderObjectsOnly = Decode.field "type" Decode.string |> Decode.andThen decoderObjectsOnlyTpe
 
@@ -218,9 +231,6 @@ class ElmJsonDecoderSpec extends FreeSpec with Matchers {
                  "ObjectTwo" -> Decode.succeed ObjectTwo
                  _ -> Decode.fail ("Unexpected type for ObjectsOnly: " ++ tpe)
            """
-      }
-    }
-
   }
 
 }

--- a/src/test/scala/bridges/elm/ElmJsonEncoderSpec.scala
+++ b/src/test/scala/bridges/elm/ElmJsonEncoderSpec.scala
@@ -186,6 +186,22 @@ class ElmJsonEncoderSpec extends FreeSpec with Matchers {
     }
   }
 
+  "Recursive" in {
+    Elm.encoder(decl[Recursive]) shouldBe
+    i"""
+      encoderRecursive : Recursive -> Encode.Value
+      encoderRecursive obj = Encode.object [ ("head", Encode.int obj.head), ("tail", Maybe.withDefault Encode.null (Maybe.map encoderRecursive obj.tail)) ]
+      """
+  }
+
+  "Recursive2" in {
+    Elm.encoder(decl[Recursive2]) shouldBe
+    i"""
+      encoderRecursive2 : Recursive2 -> Encode.Value
+      encoderRecursive2 obj = Encode.object [ ("head", Encode.int obj.head), ("tail", Encode.list (List.map encoderRecursive2 obj.tail)) ]
+      """
+  }
+
   "ObjectsOnly" in {
     Elm.encoder(decl[ObjectsOnly]) shouldBe
     i"""

--- a/src/test/scala/bridges/elm/ElmRendererSpec.scala
+++ b/src/test/scala/bridges/elm/ElmRendererSpec.scala
@@ -52,6 +52,14 @@ class ElmRendererSpec extends FreeSpec with Matchers {
     Elm.render(decl[TypeTwo]) shouldBe """type TypeTwo = OptionOne Int | OptionTwo TypeOne"""
   }
 
+  "Recursive" in {
+    Elm.render(decl[Recursive]) shouldBe """type alias Recursive = { head: Int, tail: (Maybe Recursive) }"""
+  }
+
+  "Recursive2" in {
+    Elm.render(decl[Recursive2]) shouldBe """type alias Recursive2 = { head: Int, tail: (List Recursive2) }"""
+  }
+
   "ExternalReferences" in {
     Elm.render(decl[ExternalReferences]) shouldBe """type alias ExternalReferences = { color: Color, nav: Navigation }"""
   }

--- a/src/test/scala/bridges/elm/ElmRendererSpec.scala
+++ b/src/test/scala/bridges/elm/ElmRendererSpec.scala
@@ -47,6 +47,11 @@ class ElmRendererSpec extends FreeSpec with Matchers {
     Elm.render(decl[Navigation]) shouldBe """type Navigation = Node String (List Navigation) | NodeList (List Navigation)"""
   }
 
+  "TypeOne and TypeTwo" in {
+    Elm.render(decl[TypeOne]) shouldBe """type alias TypeOne = { name: String, values: (List TypeTwo) }"""
+    Elm.render(decl[TypeTwo]) shouldBe """type TypeTwo = OptionOne Int | OptionTwo TypeOne"""
+  }
+
   "ExternalReferences" in {
     Elm.render(decl[ExternalReferences]) shouldBe """type alias ExternalReferences = { color: Color, nav: Navigation }"""
   }

--- a/src/test/scala/bridges/flow/FlowRendererSpec.scala
+++ b/src/test/scala/bridges/flow/FlowRendererSpec.scala
@@ -58,6 +58,14 @@ class FlowRendererSpec extends FreeSpec with Matchers {
     Flow.render(decl[ExternalReferences]) shouldBe """export type ExternalReferences = { color: Color, nav: Navigation };"""
   }
 
+  "Recursive" in {
+    Flow.render(decl[Recursive]) shouldBe """export type Recursive = { head: number, tail: ?Recursive };"""
+  }
+
+  "Recursive2" in {
+    Flow.render(decl[Recursive2]) shouldBe """export type Recursive2 = { head: number, tail: Recursive2[] };"""
+  }
+
   "ObjectsOnly" in {
     Flow.render(decl[ObjectsOnly]) shouldBe """export type ObjectsOnly = { type: "ObjectOne" } | { type: "ObjectTwo" };"""
   }

--- a/src/test/scala/bridges/typescript/TsRendererSpec.scala
+++ b/src/test/scala/bridges/typescript/TsRendererSpec.scala
@@ -1,7 +1,6 @@
 package bridges.typescript
 
 import bridges.SampleTypes._
-import bridges.typescript._
 import bridges.typescript.syntax._
 import org.scalatest._
 
@@ -52,6 +51,14 @@ class TsRendererSpec extends FreeSpec with Matchers {
 
   "ClassDate" in {
     Typescript.render(decl[ClassDate]) shouldBe """export type ClassDate = { a: Date };"""
+  }
+
+  "Recursive" in {
+    Typescript.render(decl[Recursive]) shouldBe """export type Recursive = { head: number, tail: Recursive | null };"""
+  }
+
+  "Recursive2" in {
+    Typescript.render(decl[Recursive2]) shouldBe """export type Recursive2 = { head: number, tail: Recursive2[] };"""
   }
 
   "ExternalReferences" in {


### PR DESCRIPTION
Add support for self-recursive type (Fix #5)

The issue seems to be specific to the aim of this library, as we use Typeable at some point to create a Ref() element, and that breaks for recursive case classes like `final case class Recursive(head: Int, tail: Option[Recursive])``

I couldn't find a way to make Typeable accept these recursive types, so I had to leave Shapeless and work with `WeakTypeTag` from scala.runtime.universe. It's hackish, but it works, and it is used only 'at the bundaries' so... I guess it's ok.

Also, this may slow down compilation a bit... sorry!