### PR TITLE
Generate "isFoo" and "asFoo" guard functions in Typescript

### DIFF
--- a/src/main/scala/bridges/typescript/TsGuardExpr.scala
+++ b/src/main/scala/bridges/typescript/TsGuardExpr.scala
@@ -1,0 +1,101 @@
+package bridges.typescript
+
+import org.apache.commons.lang3.StringEscapeUtils.{ escapeJava => escape }
+
+sealed abstract class TsGuardExpr
+
+object TsGuardExpr {
+  final case class Ref(name: String)                                                    extends TsGuardExpr
+  final case class Dot(obj: TsGuardExpr, name: String)                                  extends TsGuardExpr
+  final case class Lit(name: String)                                                    extends TsGuardExpr
+  final case class Typeof(expr: TsGuardExpr)                                            extends TsGuardExpr
+  final case class Call(func: TsGuardExpr, args: List[TsGuardExpr])                     extends TsGuardExpr
+  final case class Func(args: List[String], body: TsGuardExpr)                          extends TsGuardExpr
+  final case class Cond(test: TsGuardExpr, trueArm: TsGuardExpr, falseArm: TsGuardExpr) extends TsGuardExpr
+  final case class And(lhs: TsGuardExpr, rhs: TsGuardExpr)                              extends TsGuardExpr
+  final case class Or(lhs: TsGuardExpr, rhs: TsGuardExpr)                               extends TsGuardExpr
+  final case class Eql(lhs: TsGuardExpr, rhs: TsGuardExpr)                              extends TsGuardExpr
+
+  def ref(name: String): TsGuardExpr =
+    Ref(name)
+
+  def dot(expr: TsGuardExpr, name: String): TsGuardExpr =
+    Dot(expr, name)
+
+  def lit(value: String): TsGuardExpr =
+    Lit(s""""${escape(value)}"""")
+
+  def lit(value: Char): TsGuardExpr =
+    Lit(s""""${escape(value.toString)}"""")
+
+  def lit(value: Int): TsGuardExpr =
+    Lit(value.toString)
+
+  def lit(value: Double): TsGuardExpr =
+    Lit(value.toString)
+
+  def lit(value: Boolean): TsGuardExpr =
+    Lit(value.toString)
+
+  val nullLit: TsGuardExpr =
+    Lit("null")
+
+  def typeof(lhs: TsGuardExpr): TsGuardExpr =
+    Typeof(lhs)
+
+  def call(func: TsGuardExpr, args: TsGuardExpr*): TsGuardExpr =
+    Call(func, args.toList)
+
+  def func(args: List[String], body: TsGuardExpr): TsGuardExpr =
+    Func(args, body)
+
+  def cond(test: TsGuardExpr, trueArm: TsGuardExpr, falseArm: TsGuardExpr): TsGuardExpr =
+    Cond(test, trueArm, falseArm)
+
+  def and(lhs: TsGuardExpr, rhs: TsGuardExpr): TsGuardExpr =
+    And(lhs, rhs)
+
+  def or(lhs: TsGuardExpr, rhs: TsGuardExpr): TsGuardExpr =
+    Or(lhs, rhs)
+
+  def eql(lhs: TsGuardExpr, rhs: TsGuardExpr): TsGuardExpr =
+    Eql(lhs, rhs)
+
+  def render(expr: TsGuardExpr): String = {
+    val r = renderParens(expr) _
+
+    expr match {
+      case Ref(name)        => name
+      case Dot(obj, name)   => s"""${r(obj)}.${name}"""
+      case Lit(value)       => value
+      case Typeof(expr)     => s"""typeof ${r(expr)}"""
+      case Call(func, args) => s"""${r(func)}(${args.map(render).mkString(", ")})"""
+      case Func(args, body) => s"""(${args.mkString(", ")}) -> ${r(body)}"""
+      case Cond(c, t, f)    => s"""${r(c)} ? ${r(t)} : ${r(f)}"""
+      case And(lhs, rhs)    => s"""${r(lhs)} && ${r(rhs)}"""
+      case Or(lhs, rhs)     => s"""${r(lhs)} || ${r(rhs)}"""
+      case Eql(lhs, rhs)    => s"""${r(lhs)} === ${r(rhs)}"""
+    }
+  }
+
+  private def renderParens(outer: TsGuardExpr)(inner: TsGuardExpr): String =
+    if (precedence(outer) > precedence(inner)) {
+      s"(${render(inner)})"
+    } else {
+      render(inner)
+    }
+
+  private def precedence(tpe: TsGuardExpr): Int =
+    tpe match {
+      case _: Ref    => 1000
+      case _: Dot    => 1000
+      case _: Lit    => 1000
+      case _: Call   => 1000
+      case _: Func   => 1000
+      case _: Typeof => 900
+      case _: Eql    => 700
+      case _: And    => 600
+      case _: Or     => 500
+      case _: Cond   => 400
+    }
+}

--- a/src/main/scala/bridges/typescript/TsGuardRenderer.scala
+++ b/src/main/scala/bridges/typescript/TsGuardRenderer.scala
@@ -3,16 +3,9 @@ package bridges.typescript
 import bridges.core.{ DeclF, Renderer }
 import unindent._
 
-object TsGuardRenderer
-    extends TsGuardRenderer(
-      predName = id => s"""is${id}""",
-      guardName = id => s"""as${id}"""
-    )
+object TsGuardRenderer extends TsGuardRenderer(predName = id => s"""is${id}""", guardName = id => s"""as${id}""")
 
-abstract class TsGuardRenderer(
-    predName: String => String,
-    guardName: String => String
-) extends Renderer[TsType] {
+abstract class TsGuardRenderer(predName: String => String, guardName: String => String) extends Renderer[TsType] {
   import TsType._
   import TsGuardExpr._
 

--- a/src/main/scala/bridges/typescript/TsGuardRenderer.scala
+++ b/src/main/scala/bridges/typescript/TsGuardRenderer.scala
@@ -1,7 +1,6 @@
 package bridges.typescript
 
 import bridges.core.{ DeclF, Renderer }
-import org.apache.commons.lang3.StringEscapeUtils.{ escapeJava => escape }
 import unindent._
 
 object TsGuardRenderer
@@ -15,7 +14,7 @@ abstract class TsGuardRenderer(
     guardName: String => String
 ) extends Renderer[TsType] {
   import TsType._
-  import TsExpr._
+  import TsGuardExpr._
 
   def render(decl: TsDecl): String =
     i"""
@@ -27,7 +26,7 @@ abstract class TsGuardRenderer(
   def renderPred(decl: TsDecl): String =
     i"""
     export function ${predName(decl.name)}(v: any): boolean {
-      return ${TsExpr.render(isType(ref("v"), decl.tpe))};
+      return ${TsGuardExpr.render(isType(ref("v"), decl.tpe))};
     }
     """
 
@@ -40,9 +39,9 @@ abstract class TsGuardRenderer(
     }
     """
 
-  import TsExpr._
+  import TsGuardExpr._
 
-  private def isType(expr: TsExpr, tpe: TsType): TsExpr =
+  private def isType(expr: TsGuardExpr, tpe: TsType): TsGuardExpr =
     tpe match {
       case TsType.Ref(id)        => call(ref(predName(id)), expr)
       case TsType.Str            => eql(typeof(expr), lit("string"))
@@ -62,16 +61,16 @@ abstract class TsGuardRenderer(
       case TsType.Union(types)   => isUnion(expr, types)
     }
 
-  private def isArray(expr: TsExpr, tpe: TsType): TsExpr =
+  private def isArray(expr: TsGuardExpr, tpe: TsType): TsGuardExpr =
     and(call(dot(ref("Array"), "isArray"), expr), call(dot(expr, "reduce"), func(List("a", "i"), and(ref("a"), isType(ref("i"), tpe)))))
 
-  private def isStruct(expr: TsExpr, fields: List[TsDecl]): TsExpr =
+  private def isStruct(expr: TsGuardExpr, fields: List[TsDecl]): TsGuardExpr =
     fields
       .map { case DeclF(name, tpe) => isType(dot(expr, name), tpe) }
       .reduceLeftOption(and)
       .getOrElse(lit(true))
 
-  private def isUnion(expr: TsExpr, types: List[TsType]): TsExpr =
+  private def isUnion(expr: TsGuardExpr, types: List[TsType]): TsGuardExpr =
     types.collectAll { case tpe @ DiscriminatedBy(name, rest) => name -> rest } match {
       case Some(pairs) =>
         isDiscriminated(expr, pairs)
@@ -79,7 +78,7 @@ abstract class TsGuardRenderer(
         isAny(expr, types)
     }
 
-  private def isDiscriminated(expr: TsExpr, types: List[(String, TsType.Struct)]): TsExpr =
+  private def isDiscriminated(expr: TsGuardExpr, types: List[(String, TsType.Struct)]): TsGuardExpr =
     types match {
       case Nil =>
         lit(false)
@@ -88,13 +87,13 @@ abstract class TsGuardRenderer(
         cond(eql(dot(expr, "type"), lit(name)), isType(expr, head), isDiscriminated(expr, tail))
     }
 
-  private def isAny(expr: TsExpr, types: List[TsType]): TsExpr =
+  private def isAny(expr: TsGuardExpr, types: List[TsType]): TsGuardExpr =
     types
       .map(isType(expr, _))
       .reduceLeftOption(or)
       .getOrElse(lit(false))
 
-  private def isAll(expr: TsExpr, types: List[TsType]): TsExpr =
+  private def isAll(expr: TsGuardExpr, types: List[TsType]): TsGuardExpr =
     types
       .map(isType(expr, _))
       .reduceLeftOption(and)
@@ -120,102 +119,4 @@ abstract class TsGuardRenderer(
           None
       }
   }
-}
-
-sealed abstract class TsExpr
-
-object TsExpr {
-  final case class Ref(name: String)                                     extends TsExpr
-  final case class Dot(obj: TsExpr, name: String)                        extends TsExpr
-  final case class Lit(name: String)                                     extends TsExpr
-  final case class Typeof(expr: TsExpr)                                  extends TsExpr
-  final case class Call(func: TsExpr, args: List[TsExpr])                extends TsExpr
-  final case class Func(args: List[String], body: TsExpr)                extends TsExpr
-  final case class Cond(test: TsExpr, trueArm: TsExpr, falseArm: TsExpr) extends TsExpr
-  final case class And(lhs: TsExpr, rhs: TsExpr)                         extends TsExpr
-  final case class Or(lhs: TsExpr, rhs: TsExpr)                          extends TsExpr
-  final case class Eql(lhs: TsExpr, rhs: TsExpr)                         extends TsExpr
-
-  def ref(name: String): TsExpr =
-    Ref(name)
-
-  def dot(expr: TsExpr, name: String): TsExpr =
-    Dot(expr, name)
-
-  def lit(value: String): TsExpr =
-    Lit(s""""${escape(value)}"""")
-
-  def lit(value: Char): TsExpr =
-    Lit(s""""${escape(value.toString)}"""")
-
-  def lit(value: Int): TsExpr =
-    Lit(value.toString)
-
-  def lit(value: Double): TsExpr =
-    Lit(value.toString)
-
-  def lit(value: Boolean): TsExpr =
-    Lit(value.toString)
-
-  val nullLit: TsExpr =
-    Lit("null")
-
-  def typeof(lhs: TsExpr): TsExpr =
-    Typeof(lhs)
-
-  def call(func: TsExpr, args: TsExpr*): TsExpr =
-    Call(func, args.toList)
-
-  def func(args: List[String], body: TsExpr): TsExpr =
-    Func(args, body)
-
-  def cond(test: TsExpr, trueArm: TsExpr, falseArm: TsExpr): TsExpr =
-    Cond(test, trueArm, falseArm)
-
-  def and(lhs: TsExpr, rhs: TsExpr): TsExpr =
-    And(lhs, rhs)
-
-  def or(lhs: TsExpr, rhs: TsExpr): TsExpr =
-    Or(lhs, rhs)
-
-  def eql(lhs: TsExpr, rhs: TsExpr): TsExpr =
-    Eql(lhs, rhs)
-
-  def render(expr: TsExpr): String = {
-    val r = renderParens(expr) _
-
-    expr match {
-      case Ref(name)        => name
-      case Dot(obj, name)   => s"""${r(obj)}.${name}"""
-      case Lit(value)       => value
-      case Typeof(expr)     => s"""typeof ${r(expr)}"""
-      case Call(func, args) => s"""${r(func)}(${args.map(render).mkString(", ")})"""
-      case Func(args, body) => s"""(${args.mkString(", ")}) -> ${r(body)}"""
-      case Cond(c, t, f)    => s"""${r(c)} ? ${r(t)} : ${r(f)}"""
-      case And(lhs, rhs)    => s"""${r(lhs)} && ${r(rhs)}"""
-      case Or(lhs, rhs)     => s"""${r(lhs)} || ${r(rhs)}"""
-      case Eql(lhs, rhs)    => s"""${r(lhs)} === ${r(rhs)}"""
-    }
-  }
-
-  private def renderParens(outer: TsExpr)(inner: TsExpr): String =
-    if (precedence(outer) > precedence(inner)) {
-      s"(${render(inner)})"
-    } else {
-      render(inner)
-    }
-
-  private def precedence(tpe: TsExpr): Int =
-    tpe match {
-      case _: Ref    => 1000
-      case _: Dot    => 1000
-      case _: Lit    => 1000
-      case _: Call   => 1000
-      case _: Func   => 1000
-      case _: Typeof => 900
-      case _: Eql    => 700
-      case _: And    => 600
-      case _: Or     => 500
-      case _: Cond   => 400
-    }
 }

--- a/src/main/scala/bridges/typescript/TsGuardRenderer.scala
+++ b/src/main/scala/bridges/typescript/TsGuardRenderer.scala
@@ -1,0 +1,221 @@
+package bridges.typescript
+
+import bridges.core.{ DeclF, Renderer }
+import org.apache.commons.lang3.StringEscapeUtils.{ escapeJava => escape }
+import unindent._
+
+object TsGuardRenderer
+    extends TsGuardRenderer(
+      predName = id => s"""is${id}""",
+      guardName = id => s"""as${id}"""
+    )
+
+abstract class TsGuardRenderer(
+    predName: String => String,
+    guardName: String => String
+) extends Renderer[TsType] {
+  import TsType._
+  import TsExpr._
+
+  def render(decl: TsDecl): String =
+    i"""
+    ${renderPred(decl)}
+
+    ${renderGuard(decl)}
+    """
+
+  def renderPred(decl: TsDecl): String =
+    i"""
+    export function ${predName(decl.name)}(v: any): boolean {
+      return ${TsExpr.render(isType(ref("v"), decl.tpe))};
+    }
+    """
+
+  def renderGuard(decl: TsDecl): String =
+    i"""
+    export function ${guardName(decl.name)}(v: any): ?${decl.name} {
+      return ${predName(decl.name)}(v)
+        ? v as ${decl.name}
+        : throw new Error("Expected ${decl.name}, received " + JSON.stringify(v, null, 2));
+    }
+    """
+
+  import TsExpr._
+
+  private def isType(expr: TsExpr, tpe: TsType): TsExpr =
+    tpe match {
+      case TsType.Ref(id)        => call(ref(predName(id)), expr)
+      case TsType.Str            => eql(typeof(expr), lit("string"))
+      case TsType.Chr            => eql(typeof(expr), lit("string"))
+      case TsType.Intr           => eql(typeof(expr), lit("number"))
+      case TsType.Real           => eql(typeof(expr), lit("number"))
+      case TsType.Bool           => eql(typeof(expr), lit("boolean"))
+      case TsType.StrLit(value)  => eql(expr, lit(value))
+      case TsType.ChrLit(value)  => eql(expr, lit(value.toString))
+      case TsType.IntrLit(value) => eql(expr, lit(value))
+      case TsType.RealLit(value) => eql(expr, lit(value))
+      case TsType.BoolLit(value) => eql(expr, lit(value))
+      case TsType.Null           => eql(expr, nullLit)
+      case TsType.Arr(tpe)       => isArray(expr, tpe)
+      case TsType.Struct(fields) => isStruct(expr, fields)
+      case TsType.Inter(types)   => isAll(expr, types)
+      case TsType.Union(types)   => isUnion(expr, types)
+    }
+
+  private def isArray(expr: TsExpr, tpe: TsType): TsExpr =
+    and(call(dot(ref("Array"), "isArray"), expr), call(dot(expr, "reduce"), func(List("a", "i"), and(ref("a"), isType(ref("i"), tpe)))))
+
+  private def isStruct(expr: TsExpr, fields: List[TsDecl]): TsExpr =
+    fields
+      .map { case DeclF(name, tpe) => isType(dot(expr, name), tpe) }
+      .reduceLeftOption(and)
+      .getOrElse(lit(true))
+
+  private def isUnion(expr: TsExpr, types: List[TsType]): TsExpr =
+    types.collectAll { case tpe @ DiscriminatedBy(name, rest) => name -> rest } match {
+      case Some(pairs) =>
+        isDiscriminated(expr, pairs)
+      case None =>
+        isAny(expr, types)
+    }
+
+  private def isDiscriminated(expr: TsExpr, types: List[(String, TsType.Struct)]): TsExpr =
+    types match {
+      case Nil =>
+        lit(false)
+
+      case (name, head) :: tail =>
+        cond(eql(dot(expr, "type"), lit(name)), isType(expr, head), isDiscriminated(expr, tail))
+    }
+
+  private def isAny(expr: TsExpr, types: List[TsType]): TsExpr =
+    types
+      .map(isType(expr, _))
+      .reduceLeftOption(or)
+      .getOrElse(lit(false))
+
+  private def isAll(expr: TsExpr, types: List[TsType]): TsExpr =
+    types
+      .map(isType(expr, _))
+      .reduceLeftOption(and)
+      .getOrElse(lit(true))
+
+  private implicit class ListOps[A](list: List[A]) {
+    def collectAll[B](func: PartialFunction[A, B]): Option[List[B]] = {
+      val temp = list.collect(func)
+      if (temp.length == list.length) Some(temp) else None
+    }
+  }
+
+  private object DiscriminatedBy {
+    def unapply(tpe: TsType): Option[(String, TsType.Struct)] =
+      tpe match {
+        case TsType.Struct(fields) =>
+          fields.collectFirst {
+            case decl @ DeclF("type", TsType.StrLit(name)) =>
+              (name, TsType.Struct(fields.filterNot(_ == decl)))
+          }
+
+        case _ =>
+          None
+      }
+  }
+}
+
+sealed abstract class TsExpr
+
+object TsExpr {
+  final case class Ref(name: String)                                     extends TsExpr
+  final case class Dot(obj: TsExpr, name: String)                        extends TsExpr
+  final case class Lit(name: String)                                     extends TsExpr
+  final case class Typeof(expr: TsExpr)                                  extends TsExpr
+  final case class Call(func: TsExpr, args: List[TsExpr])                extends TsExpr
+  final case class Func(args: List[String], body: TsExpr)                extends TsExpr
+  final case class Cond(test: TsExpr, trueArm: TsExpr, falseArm: TsExpr) extends TsExpr
+  final case class And(lhs: TsExpr, rhs: TsExpr)                         extends TsExpr
+  final case class Or(lhs: TsExpr, rhs: TsExpr)                          extends TsExpr
+  final case class Eql(lhs: TsExpr, rhs: TsExpr)                         extends TsExpr
+
+  def ref(name: String): TsExpr =
+    Ref(name)
+
+  def dot(expr: TsExpr, name: String): TsExpr =
+    Dot(expr, name)
+
+  def lit(value: String): TsExpr =
+    Lit(s""""${escape(value)}"""")
+
+  def lit(value: Char): TsExpr =
+    Lit(s""""${escape(value.toString)}"""")
+
+  def lit(value: Int): TsExpr =
+    Lit(value.toString)
+
+  def lit(value: Double): TsExpr =
+    Lit(value.toString)
+
+  def lit(value: Boolean): TsExpr =
+    Lit(value.toString)
+
+  val nullLit: TsExpr =
+    Lit("null")
+
+  def typeof(lhs: TsExpr): TsExpr =
+    Typeof(lhs)
+
+  def call(func: TsExpr, args: TsExpr*): TsExpr =
+    Call(func, args.toList)
+
+  def func(args: List[String], body: TsExpr): TsExpr =
+    Func(args, body)
+
+  def cond(test: TsExpr, trueArm: TsExpr, falseArm: TsExpr): TsExpr =
+    Cond(test, trueArm, falseArm)
+
+  def and(lhs: TsExpr, rhs: TsExpr): TsExpr =
+    And(lhs, rhs)
+
+  def or(lhs: TsExpr, rhs: TsExpr): TsExpr =
+    Or(lhs, rhs)
+
+  def eql(lhs: TsExpr, rhs: TsExpr): TsExpr =
+    Eql(lhs, rhs)
+
+  def render(expr: TsExpr): String = {
+    val r = renderParens(expr) _
+
+    expr match {
+      case Ref(name)        => name
+      case Dot(obj, name)   => s"""${r(obj)}.${name}"""
+      case Lit(value)       => value
+      case Typeof(expr)     => s"""typeof ${r(expr)}"""
+      case Call(func, args) => s"""${r(func)}(${args.map(render).mkString(", ")})"""
+      case Func(args, body) => s"""(${args.mkString(", ")}) -> ${r(body)}"""
+      case Cond(c, t, f)    => s"""${r(c)} ? ${r(t)} : ${r(f)}"""
+      case And(lhs, rhs)    => s"""${r(lhs)} && ${r(rhs)}"""
+      case Or(lhs, rhs)     => s"""${r(lhs)} || ${r(rhs)}"""
+      case Eql(lhs, rhs)    => s"""${r(lhs)} === ${r(rhs)}"""
+    }
+  }
+
+  private def renderParens(outer: TsExpr)(inner: TsExpr): String =
+    if (precedence(outer) > precedence(inner)) {
+      s"(${render(inner)})"
+    } else {
+      render(inner)
+    }
+
+  private def precedence(tpe: TsExpr): Int =
+    tpe match {
+      case _: Ref    => 1000
+      case _: Dot    => 1000
+      case _: Lit    => 1000
+      case _: Call   => 1000
+      case _: Func   => 1000
+      case _: Typeof => 900
+      case _: Eql    => 700
+      case _: And    => 600
+      case _: Or     => 500
+      case _: Cond   => 400
+    }
+}

--- a/src/main/scala/bridges/typescript/TsRenderer.scala
+++ b/src/main/scala/bridges/typescript/TsRenderer.scala
@@ -1,64 +1,16 @@
 package bridges.typescript
 
 import bridges.core.Renderer
-import org.apache.commons.lang3.StringEscapeUtils.{ escapeJava => escape }
+import unindent._
 
-trait TsRenderer extends Renderer[TsType] {
-  import TsType._
-
+abstract class TsRenderer(
+    typeRenderer: Renderer[TsType],
+    guardRenderer: Renderer[TsType]
+) extends Renderer[TsType] {
   def render(decl: TsDecl): String =
-    s"export type ${decl.name} = ${renderType(decl.tpe)};"
+    i"""
+    ${typeRenderer.render(decl)}
 
-  private def renderType(tpe: TsType): String =
-    tpe match {
-      case Ref(id)            => id
-      case Str                => "string"
-      case Chr                => "string"
-      case Intr               => "number"
-      case Real               => "number"
-      case Bool               => "boolean"
-      case Null               => "null"
-      case StrLit(value)      => s""""${escape(value)}""""
-      case ChrLit(value)      => s""""${escape(value.toString)}""""
-      case IntrLit(value)     => value.toString
-      case RealLit(value)     => value.toString
-      case BoolLit(value)     => value.toString
-      case tpe @ Arr(arg)     => s"""${renderParens(tpe)(arg)}[]"""
-      case Struct(fields)     => renderStruct(fields)
-      case tpe @ Inter(types) => types.map(renderParens(tpe)).mkString(" & ")
-      case tpe @ Union(types) => types.map(renderParens(tpe)).mkString(" | ")
-    }
-
-  private def renderStruct(fields: List[TsDecl]): String =
-    fields.map(renderField).mkString("{ ", ", ", " }")
-
-  private def renderField(field: TsDecl): String =
-    s"""${field.name}: ${renderType(field.tpe)}"""
-
-  private def renderParens(outer: TsType)(inner: TsType): String =
-    if (precedence(outer) > precedence(inner)) {
-      s"(${renderType(inner)})"
-    } else {
-      renderType(inner)
-    }
-
-  private def precedence(tpe: TsType): Int =
-    tpe match {
-      case _: Ref     => 1000
-      case _ @Str     => 1000
-      case _ @Chr     => 1000
-      case _ @Intr    => 1000
-      case _ @Real    => 1000
-      case _ @Bool    => 1000
-      case _ @Null    => 1000
-      case _: StrLit  => 1000
-      case _: ChrLit  => 1000
-      case _: IntrLit => 1000
-      case _: RealLit => 1000
-      case _: BoolLit => 1000
-      case _: Arr     => 900
-      case _: Struct  => 600
-      case _: Union   => 400
-      case _: Inter   => 200
-    }
+    ${guardRenderer.render(decl)}
+    """
 }

--- a/src/main/scala/bridges/typescript/TsType.scala
+++ b/src/main/scala/bridges/typescript/TsType.scala
@@ -48,11 +48,12 @@ object TsType {
   final case object Real                        extends TsType
   final case object Bool                        extends TsType
   final case object Null                        extends TsType
-  final case class StrLit(value: String)        extends TsType
-  final case class ChrLit(value: Char)          extends TsType
-  final case class IntrLit(value: Int)          extends TsType
-  final case class RealLit(value: Double)       extends TsType
-  final case class BoolLit(value: Boolean)      extends TsType
+  sealed abstract class TsLiteralType           extends TsType
+  final case class StrLit(value: String)        extends TsLiteralType
+  final case class ChrLit(value: Char)          extends TsLiteralType
+  final case class IntrLit(value: Int)          extends TsLiteralType
+  final case class RealLit(value: Double)       extends TsLiteralType
+  final case class BoolLit(value: Boolean)      extends TsLiteralType
   final case class Arr(tpe: TsType)             extends TsType
   final case class Struct(fields: List[TsDecl]) extends TsType
   final case class Inter(types: List[TsType])   extends TsType

--- a/src/main/scala/bridges/typescript/TsType.scala
+++ b/src/main/scala/bridges/typescript/TsType.scala
@@ -48,12 +48,11 @@ object TsType {
   final case object Real                        extends TsType
   final case object Bool                        extends TsType
   final case object Null                        extends TsType
-  sealed abstract class TsLiteralType           extends TsType
-  final case class StrLit(value: String)        extends TsLiteralType
-  final case class ChrLit(value: Char)          extends TsLiteralType
-  final case class IntrLit(value: Int)          extends TsLiteralType
-  final case class RealLit(value: Double)       extends TsLiteralType
-  final case class BoolLit(value: Boolean)      extends TsLiteralType
+  final case class StrLit(value: String)        extends TsType
+  final case class ChrLit(value: Char)          extends TsType
+  final case class IntrLit(value: Int)          extends TsType
+  final case class RealLit(value: Double)       extends TsType
+  final case class BoolLit(value: Boolean)      extends TsType
   final case class Arr(tpe: TsType)             extends TsType
   final case class Struct(fields: List[TsDecl]) extends TsType
   final case class Inter(types: List[TsType])   extends TsType

--- a/src/main/scala/bridges/typescript/TsTypeRenderer.scala
+++ b/src/main/scala/bridges/typescript/TsTypeRenderer.scala
@@ -1,0 +1,66 @@
+package bridges.typescript
+
+import bridges.core.Renderer
+import org.apache.commons.lang3.StringEscapeUtils.{ escapeJava => escape }
+
+object TsTypeRenderer extends TsTypeRenderer(true)
+
+abstract class TsTypeRenderer(exportAll: Boolean) extends Renderer[TsType] {
+  import TsType._
+
+  def render(decl: TsDecl): String =
+    s"${if (exportAll) "export type" else "type"} ${decl.name} = ${renderType(decl.tpe)};"
+
+  private def renderType(tpe: TsType): String =
+    tpe match {
+      case Ref(id)            => id
+      case Str                => "string"
+      case Chr                => "string"
+      case Intr               => "number"
+      case Real               => "number"
+      case Bool               => "boolean"
+      case Null               => "null"
+      case StrLit(value)      => s""""${escape(value)}""""
+      case ChrLit(value)      => s""""${escape(value.toString)}""""
+      case IntrLit(value)     => value.toString
+      case RealLit(value)     => value.toString
+      case BoolLit(value)     => value.toString
+      case tpe @ Arr(arg)     => s"""${renderParens(tpe)(arg)}[]"""
+      case Struct(fields)     => renderStruct(fields)
+      case tpe @ Inter(types) => types.map(renderParens(tpe)).mkString(" & ")
+      case tpe @ Union(types) => types.map(renderParens(tpe)).mkString(" | ")
+    }
+
+  private def renderStruct(fields: List[TsDecl]): String =
+    fields.map(renderField).mkString("{ ", ", ", " }")
+
+  private def renderField(field: TsDecl): String =
+    s"""${field.name}: ${renderType(field.tpe)}"""
+
+  private def renderParens(outer: TsType)(inner: TsType): String =
+    if (precedence(outer) > precedence(inner)) {
+      s"(${renderType(inner)})"
+    } else {
+      renderType(inner)
+    }
+
+  private def precedence(tpe: TsType): Int =
+    tpe match {
+      case _: Ref     => 1000
+      case _ @Str     => 1000
+      case _ @Chr     => 1000
+      case _ @Intr    => 1000
+      case _ @Real    => 1000
+      case _ @Bool    => 1000
+      case _ @Null    => 1000
+      case _: StrLit  => 1000
+      case _: ChrLit  => 1000
+      case _: IntrLit => 1000
+      case _: RealLit => 1000
+      case _: BoolLit => 1000
+      case _: Arr     => 900
+      case _: Struct  => 600
+      case _: Union   => 400
+      case _: Inter   => 200
+    }
+}

--- a/src/main/scala/bridges/typescript/Typescript.scala
+++ b/src/main/scala/bridges/typescript/Typescript.scala
@@ -1,3 +1,3 @@
 package bridges.typescript
 
-object Typescript extends TsRenderer
+object Typescript extends TsRenderer(TsTypeRenderer, TsGuardRenderer)

--- a/src/test/scala/bridges/typescript/TsGuardRendererSpec.scala
+++ b/src/test/scala/bridges/typescript/TsGuardRendererSpec.scala
@@ -1,0 +1,203 @@
+package bridges.typescript
+
+import bridges.SampleTypes._
+import bridges.typescript.TsType._
+import bridges.typescript.syntax._
+import org.scalatest._
+import unindent._
+
+class TsGuardRendererSpec extends FreeSpec with Matchers {
+  "Color" in {
+    TsGuardRenderer.render(decl[Color]) shouldBe {
+      i"""
+      export function isColor(v: any): boolean {
+        return typeof v.red === "number" && typeof v.green === "number" && typeof v.blue === "number";
+      }
+
+      export function asColor(v: any): ?Color {
+        return isColor(v)
+          ? v as Color
+          : throw new Error("Expected Color, received " + JSON.stringify(v, null, 2));
+      }
+      """
+    }
+
+    TsGuardRenderer.renderPred(decl[Color]) shouldBe {
+      i"""
+      export function isColor(v: any): boolean {
+        return typeof v.red === "number" && typeof v.green === "number" && typeof v.blue === "number";
+      }
+      """
+    }
+  }
+
+  "Circle" in {
+    TsGuardRenderer.renderPred(decl[Circle]) shouldBe {
+      i"""
+      export function isCircle(v: any): boolean {
+        return typeof v.radius === "number" && isColor(v.color);
+      }
+      """
+    }
+  }
+
+  "Rectangle" in {
+    TsGuardRenderer.renderPred(decl[Rectangle]) shouldBe {
+      i"""
+      export function isRectangle(v: any): boolean {
+        return typeof v.width === "number" && typeof v.height === "number" && isColor(v.color);
+      }
+      """
+    }
+  }
+
+  "Shape" in {
+    TsGuardRenderer.renderPred(decl[Shape]) shouldBe {
+      i"""
+      export function isShape(v: any): boolean {
+        return v.type === "Circle" ? typeof v.radius === "number" && isColor(v.color) : v.type === "Rectangle" ? typeof v.width === "number" && typeof v.height === "number" && isColor(v.color) : v.type === "ShapeGroup" ? isShape(v.leftShape) && isShape(v.rightShape) : false;
+      }
+      """
+    }
+  }
+
+  "Alpha" in {
+    TsGuardRenderer.renderPred(decl[Alpha]) shouldBe {
+      i"""
+      export function isAlpha(v: any): boolean {
+        return typeof v.name === "string" && typeof v.char === "string" && typeof v.bool === "boolean";
+      }
+      """
+    }
+  }
+
+  "ArrayClass" in {
+    TsGuardRenderer.renderPred(decl[ArrayClass]) shouldBe {
+      i"""
+      export function isArrayClass(v: any): boolean {
+        return Array.isArray(v.aList) && v.aList.reduce((a, i) -> (a && typeof i === "string")) && (typeof v.optField === "number" || v.optField === null);
+      }
+      """
+    }
+  }
+
+  "Numeric" in {
+    TsGuardRenderer.renderPred(decl[Numeric]) shouldBe {
+      i"""
+      export function isNumeric(v: any): boolean {
+        return typeof v.double === "number" && typeof v.float === "number" && typeof v.int === "number";
+      }
+      """
+    }
+  }
+
+  "ClassOrObject" in {
+    TsGuardRenderer.renderPred(decl[ClassOrObject]) shouldBe {
+      i"""
+      export function isClassOrObject(v: any): boolean {
+        return v.type === "MyClass" ? typeof v.value === "number" : v.type === "MyObject" ? true : false;
+      }
+      """
+    }
+  }
+
+  "NestedClassOrObject" in {
+    TsGuardRenderer.renderPred(decl[NestedClassOrObject]) shouldBe {
+      i"""
+      export function isNestedClassOrObject(v: any): boolean {
+        return v.type === "MyClass" ? typeof v.value === "number" : v.type === "MyObject" ? true : false;
+      }
+      """
+    }
+  }
+
+  "Navigation" in {
+    TsGuardRenderer.renderPred(decl[Navigation]) shouldBe {
+      i"""
+      export function isNavigation(v: any): boolean {
+        return v.type === "Node" ? typeof v.name === "string" && Array.isArray(v.children) && v.children.reduce((a, i) -> (a && isNavigation(i))) : v.type === "NodeList" ? Array.isArray(v.all) && v.all.reduce((a, i) -> (a && isNavigation(i))) : false;
+      }
+      """
+    }
+  }
+
+  "ClassUUID" in {
+    TsGuardRenderer.renderPred(decl[ClassUUID]) shouldBe {
+      i"""
+      export function isClassUUID(v: any): boolean {
+        return isUUID(v.a);
+      }
+      """
+    }
+  }
+
+  "ClassDate" in {
+    TsGuardRenderer.renderPred(decl[ClassDate]) shouldBe {
+      i"""
+      export function isClassDate(v: any): boolean {
+        return isDate(v.a);
+      }
+      """
+    }
+  }
+
+  "Recursive" in {
+    TsGuardRenderer.renderPred(decl[Recursive]) shouldBe {
+      i"""
+      export function isRecursive(v: any): boolean {
+        return typeof v.head === "number" && (isRecursive(v.tail) || v.tail === null);
+      }
+      """
+    }
+  }
+
+  "Recursive2" in {
+    TsGuardRenderer.renderPred(decl[Recursive2]) shouldBe {
+      i"""
+      export function isRecursive2(v: any): boolean {
+        return typeof v.head === "number" && Array.isArray(v.tail) && v.tail.reduce((a, i) -> (a && isRecursive2(i)));
+      }
+      """
+    }
+  }
+
+  "ExternalReferences" in {
+    TsGuardRenderer.renderPred(decl[ExternalReferences]) shouldBe {
+      i"""
+      export function isExternalReferences(v: any): boolean {
+        return isColor(v.color) && isNavigation(v.nav);
+      }
+      """
+    }
+  }
+
+  "ObjectsOnly" in {
+    TsGuardRenderer.renderPred(decl[ObjectsOnly]) shouldBe {
+      i"""
+      export function isObjectsOnly(v: any): boolean {
+        return v.type === "ObjectOne" ? true : v.type === "ObjectTwo" ? true : false;
+      }
+      """
+    }
+  }
+
+  "Union of Union" in {
+    TsGuardRenderer.renderPred("A" := Ref("B") | Ref("C") | Ref("D")) shouldBe {
+      i"""
+      export function isA(v: any): boolean {
+        return isB(v) || isC(v) || isD(v);
+      }
+      """
+    }
+  }
+
+  "Inter of Inter" in {
+    TsGuardRenderer.renderPred("A" := Ref("B") & Ref("C") & Ref("D")) shouldBe {
+      i"""
+      export function isA(v: any): boolean {
+        return isB(v) && isC(v) && isD(v);
+      }
+      """
+    }
+  }
+}

--- a/src/test/scala/bridges/typescript/TsRendererSpec.scala
+++ b/src/test/scala/bridges/typescript/TsRendererSpec.scala
@@ -4,77 +4,150 @@ import bridges.SampleTypes._
 import bridges.typescript.TsType._
 import bridges.typescript.syntax._
 import org.scalatest._
+import unindent._
 
 class TsRendererSpec extends FreeSpec with Matchers {
   "Color" in {
-    Typescript.render(decl[Color]) shouldBe "export type Color = { red: number, green: number, blue: number };"
+    TsTypeRenderer.render(decl[Color]) shouldBe {
+      i"""
+      export type Color = { red: number, green: number, blue: number };
+      """
+    }
   }
 
   "Circle" in {
-    Typescript.render(decl[Circle]) shouldBe "export type Circle = { radius: number, color: Color };"
+    TsTypeRenderer.render(decl[Circle]) shouldBe {
+      i"""
+      export type Circle = { radius: number, color: Color };
+      """
+    }
   }
 
   "Rectangle" in {
-    Typescript.render(decl[Rectangle]) shouldBe "export type Rectangle = { width: number, height: number, color: Color };"
+    TsTypeRenderer.render(decl[Rectangle]) shouldBe {
+      i"""
+      export type Rectangle = { width: number, height: number, color: Color };
+      """
+    }
   }
 
   "Shape" in {
-    Typescript.render(decl[Shape]) shouldBe """export type Shape = { type: "Circle", radius: number, color: Color } | { type: "Rectangle", width: number, height: number, color: Color } | { type: "ShapeGroup", leftShape: Shape, rightShape: Shape };"""
+    TsTypeRenderer.render(decl[Shape]) shouldBe {
+      i"""
+      export type Shape = { type: "Circle", radius: number, color: Color } | { type: "Rectangle", width: number, height: number, color: Color } | { type: "ShapeGroup", leftShape: Shape, rightShape: Shape };
+      """
+    }
   }
 
   "Alpha" in {
-    Typescript.render(decl[Alpha]) shouldBe "export type Alpha = { name: string, char: string, bool: boolean };"
+    TsTypeRenderer.render(decl[Alpha]) shouldBe {
+      i"""
+      export type Alpha = { name: string, char: string, bool: boolean };
+      """
+    }
   }
 
   "ArrayClass" in {
-    Typescript.render(decl[ArrayClass]) shouldBe """export type ArrayClass = { aList: string[], optField: number | null };"""
+    TsTypeRenderer.render(decl[ArrayClass]) shouldBe {
+      i"""
+      export type ArrayClass = { aList: string[], optField: number | null };
+      """
+    }
   }
 
   "Numeric" in {
-    Typescript.render(decl[Numeric]) shouldBe """export type Numeric = { double: number, float: number, int: number };"""
+    TsTypeRenderer.render(decl[Numeric]) shouldBe {
+      i"""
+      export type Numeric = { double: number, float: number, int: number };
+      """
+    }
   }
 
   "ClassOrObject" in {
-    Typescript.render(decl[ClassOrObject]) shouldBe """export type ClassOrObject = { type: "MyClass", value: number } | { type: "MyObject" };"""
+    TsTypeRenderer.render(decl[ClassOrObject]) shouldBe {
+      i"""
+      export type ClassOrObject = { type: "MyClass", value: number } | { type: "MyObject" };
+      """
+    }
   }
 
   "NestedClassOrObject" in {
-    Typescript.render(decl[NestedClassOrObject]) shouldBe """export type NestedClassOrObject = { type: "MyClass", value: number } | { type: "MyObject" };"""
+    TsTypeRenderer.render(decl[NestedClassOrObject]) shouldBe {
+      i"""
+      export type NestedClassOrObject = { type: "MyClass", value: number } | { type: "MyObject" };
+      """
+    }
   }
 
   "Navigation" in {
-    Typescript.render(decl[Navigation]) shouldBe """export type Navigation = { type: "Node", name: string, children: Navigation[] } | { type: "NodeList", all: Navigation[] };"""
+    TsTypeRenderer.render(decl[Navigation]) shouldBe {
+      i"""
+      export type Navigation = { type: "Node", name: string, children: Navigation[] } | { type: "NodeList", all: Navigation[] };
+      """
+    }
   }
 
   "ClassUUID" in {
-    Typescript.render(decl[ClassUUID]) shouldBe """export type ClassUUID = { a: UUID };"""
+    TsTypeRenderer.render(decl[ClassUUID]) shouldBe {
+      i"""
+      export type ClassUUID = { a: UUID };
+      """
+    }
   }
 
   "ClassDate" in {
-    Typescript.render(decl[ClassDate]) shouldBe """export type ClassDate = { a: Date };"""
+    TsTypeRenderer.render(decl[ClassDate]) shouldBe {
+      i"""
+      export type ClassDate = { a: Date };
+      """
+    }
   }
 
   "Recursive" in {
-    Typescript.render(decl[Recursive]) shouldBe """export type Recursive = { head: number, tail: Recursive | null };"""
+    TsTypeRenderer.render(decl[Recursive]) shouldBe {
+      i"""
+      export type Recursive = { head: number, tail: Recursive | null };
+      """
+    }
   }
 
   "Recursive2" in {
-    Typescript.render(decl[Recursive2]) shouldBe """export type Recursive2 = { head: number, tail: Recursive2[] };"""
+    TsTypeRenderer.render(decl[Recursive2]) shouldBe {
+      i"""
+      export type Recursive2 = { head: number, tail: Recursive2[] };
+      """
+    }
   }
 
   "ExternalReferences" in {
-    Typescript.render(decl[ExternalReferences]) shouldBe """export type ExternalReferences = { color: Color, nav: Navigation };"""
+    TsTypeRenderer.render(decl[ExternalReferences]) shouldBe {
+      i"""
+      export type ExternalReferences = { color: Color, nav: Navigation };
+      """
+    }
   }
 
   "ObjectsOnly" in {
-    Typescript.render(decl[ObjectsOnly]) shouldBe """export type ObjectsOnly = { type: "ObjectOne" } | { type: "ObjectTwo" };"""
+    TsTypeRenderer.render(decl[ObjectsOnly]) shouldBe {
+      i"""
+      export type ObjectsOnly = { type: "ObjectOne" } | { type: "ObjectTwo" };
+      """
+    }
   }
 
   "Union of Union" in {
-    Typescript.render("A" := Ref("B") | Ref("C") | Ref("D")) shouldBe """export type A = B | C | D;"""
+    TsTypeRenderer.render("A" := Ref("B") | Ref("C") | Ref("D")) shouldBe {
+      i"""
+      export type A = B | C | D;
+      """
+    }
   }
 
   "Inter of Inter" in {
-    Typescript.render("A" := Ref("B") & Ref("C") & Ref("D")) shouldBe """export type A = B & C & D;"""
+    TsTypeRenderer.render("A" := Ref("B") & Ref("C") & Ref("D")) shouldBe {
+      i"""
+      export type A = B & C & D;
+      """
+    }
   }
 }


### PR DESCRIPTION
This PR adjusts the behaviour of the Typescript generator to generate three definitions instead of one, summarised as follows:

```scala
export type Foo = ???

export function isFoo(v: any): boolean {
  return ???
}

export function asFoo(v: any): Foo {
  return isFoo(v) ? (v as Foo) : throw new Error("Badness");
}
```

In the absence of a standard JSON codec library, this seems like the simplest way to check the validity of incoming data at runtime.
