### PR TITLE
Fix Typescript guard functions for generic types

### DIFF
--- a/src/main/scala/bridges/typescript/TsGuardRenderer.scala
+++ b/src/main/scala/bridges/typescript/TsGuardRenderer.scala
@@ -37,7 +37,7 @@ abstract class TsGuardRenderer(
     }
 
   def renderParamPreds(params: List[String]): String =
-    params.map(param => s"${predName(param)}: (${param.toLowerCase}: any) => boolean").mkString(", ")
+    params.map(param => s"${predName(param)}: (${param.toLowerCase}: any) => ${param.toLowerCase} is ${param}").mkString(", ")
 
   import TsGuardExpr._
 

--- a/src/test/scala/bridges/typescript/TsGuardRendererSpec.scala
+++ b/src/test/scala/bridges/typescript/TsGuardRendererSpec.scala
@@ -197,7 +197,7 @@ class TsGuardRendererSpec extends FreeSpec with Matchers {
       )
     ) shouldBe {
       i"""
-      export const isPair = <A, B>(isA: (a: any) => boolean, isB: (b: any) => boolean) => (v: any): v is Pair<A, B> => {
+      export const isPair = <A, B>(isA: (a: any) => a is A, isB: (b: any) => b is B) => (v: any): v is Pair<A, B> => {
         return typeof v === "object" && v != null && "a" in v && isA(v.a) && (!("b" in v) || isB(v.b));
       }
       """
@@ -215,7 +215,7 @@ class TsGuardRendererSpec extends FreeSpec with Matchers {
 
     TypescriptGuard.render(decl("Same", "A")(ref("Pair", ref("A"), ref("A")))) shouldBe {
       i"""
-      export const isSame = <A>(isA: (a: any) => boolean) => (v: any): v is Same<A> => {
+      export const isSame = <A>(isA: (a: any) => a is A) => (v: any): v is Same<A> => {
         return isPair((a0: any) => isA(a0), (a1: any) => isA(a1))(v);
       }
       """


### PR DESCRIPTION
Guard functions should always have return types of the form `name is Type`, not `boolean`.