### PR TITLE
Extra type annotations on guard functions

### DIFF
--- a/src/main/scala/bridges/typescript/TsGuardRenderer.scala
+++ b/src/main/scala/bridges/typescript/TsGuardRenderer.scala
@@ -44,7 +44,7 @@ abstract class TsGuardRenderer(
   def guardFunc(pair: (TsType, Int)): TsGuardExpr = {
     val (tpe, index) = pair
     val arg          = "a" + index
-    func(arg)(isType(ref(arg), tpe))
+    guard(arg, tpe)(isType(ref(arg), tpe))
   }
 
   def isType(arg: TsGuardExpr, tpe: TsType): TsGuardExpr =

--- a/src/main/scala/bridges/typescript/TsTypeRenderer.scala
+++ b/src/main/scala/bridges/typescript/TsTypeRenderer.scala
@@ -15,7 +15,7 @@ abstract class TsTypeRenderer(exportAll: Boolean) extends Renderer[TsType] {
         s"${if (exportAll) "export type" else "type"} ${renderParams(name, params)} = ${renderType(tpe)};"
     }
 
-  private def renderType(tpe: TsType): String =
+  def renderType(tpe: TsType): String =
     tpe match {
       case Ref(id, params)      => renderRef(id, params)
       case Any                  => "any"

--- a/src/test/scala/bridges/typescript/TsGuardRendererSpec.scala
+++ b/src/test/scala/bridges/typescript/TsGuardRendererSpec.scala
@@ -208,7 +208,7 @@ class TsGuardRendererSpec extends FreeSpec with Matchers {
     TypescriptGuard.render(decl("Cell")(ref("Pair", Str, Intr))) shouldBe {
       i"""
       export const isCell = (v: any): v is Cell => {
-        return isPair((a0: any) => typeof a0 === "string", (a1: any) => typeof a1 === "number")(v);
+        return isPair((a0: any): a0 is string => typeof a0 === "string", (a1: any): a1 is number => typeof a1 === "number")(v);
       }
       """
     }
@@ -216,7 +216,7 @@ class TsGuardRendererSpec extends FreeSpec with Matchers {
     TypescriptGuard.render(decl("Same", "A")(ref("Pair", ref("A"), ref("A")))) shouldBe {
       i"""
       export const isSame = <A>(isA: (a: any) => a is A) => (v: any): v is Same<A> => {
-        return isPair((a0: any) => isA(a0), (a1: any) => isA(a1))(v);
+        return isPair((a0: any): a0 is A => isA(a0), (a1: any): a1 is A => isA(a1))(v);
       }
       """
     }
@@ -224,7 +224,7 @@ class TsGuardRendererSpec extends FreeSpec with Matchers {
     TypescriptGuard.render(decl("AnyPair")(ref("Pair", Any, Any))) shouldBe {
       i"""
       export const isAnyPair = (v: any): v is AnyPair => {
-        return isPair((a0: any) => true, (a1: any) => true)(v);
+        return isPair((a0: any): a0 is any => true, (a1: any): a1 is any => true)(v);
       }
       """
     }


### PR DESCRIPTION
Adds a couple of extra annotations to suppress type errors in corner cases to do with generic types:

```typescript
function isPair<A, B>(isA: (a: any) => a is A, (b: any) => b is B): (pair: any): pair is Pair<A, B> {
  // ...
}

export const isAnyPair = (v: any): v is Pair<any, any> => {
  return isPair((a0: any): a0 is any => true, (a1: any): a1 is any => true)(v); // HERE
}
```

The `foo is Bar` annotations on the line marked "HERE" are required to make things compile.