### PR TITLE
Fix missing argument to array.reduce() in Typescript guards

### DIFF
--- a/src/main/scala/bridges/typescript/TsGuardRenderer.scala
+++ b/src/main/scala/bridges/typescript/TsGuardRenderer.scala
@@ -80,7 +80,8 @@ abstract class TsGuardRenderer(
       call(dot(ref("Array"), "isArray"), expr),
       call(
         dot(call(dot(expr, "map"), func("i")(isType(ref("i"), tpe))), "reduce"),
-        func("a", "b")(and(ref("a"), ref("b")))
+        func("a", "b")(and(ref("a"), ref("b"))),
+        lit(true)
       )
     )
 

--- a/src/test/scala/bridges/typescript/TsGuardRendererSpec.scala
+++ b/src/test/scala/bridges/typescript/TsGuardRendererSpec.scala
@@ -61,7 +61,7 @@ class TsGuardRendererSpec extends FreeSpec with Matchers {
     TypescriptGuard.render(decl[ArrayClass]) shouldBe {
       i"""
       export const isArrayClass = (v: any): v is ArrayClass => {
-        return typeof v === "object" && v != null && "aList" in v && Array.isArray(v.aList) && v.aList.map((i: any) => typeof i === "string").reduce((a: any, b: any) => a && b) && (!("optField" in v) || typeof v.optField === "number" || v.optField === null);
+        return typeof v === "object" && v != null && "aList" in v && Array.isArray(v.aList) && v.aList.map((i: any) => typeof i === "string").reduce((a: any, b: any) => a && b, true) && (!("optField" in v) || typeof v.optField === "number" || v.optField === null);
       }
       """
     }
@@ -101,7 +101,7 @@ class TsGuardRendererSpec extends FreeSpec with Matchers {
     TypescriptGuard.render(decl[Navigation]) shouldBe {
       i"""
       export const isNavigation = (v: any): v is Navigation => {
-        return typeof v === "object" && v != null && "type" in v && (v.type === "Node" ? typeof v === "object" && v != null && "name" in v && typeof v.name === "string" && "children" in v && Array.isArray(v.children) && v.children.map((i: any) => isNavigation(i)).reduce((a: any, b: any) => a && b) : v.type === "NodeList" ? typeof v === "object" && v != null && "all" in v && Array.isArray(v.all) && v.all.map((i: any) => isNavigation(i)).reduce((a: any, b: any) => a && b) : false);
+        return typeof v === "object" && v != null && "type" in v && (v.type === "Node" ? typeof v === "object" && v != null && "name" in v && typeof v.name === "string" && "children" in v && Array.isArray(v.children) && v.children.map((i: any) => isNavigation(i)).reduce((a: any, b: any) => a && b, true) : v.type === "NodeList" ? typeof v === "object" && v != null && "all" in v && Array.isArray(v.all) && v.all.map((i: any) => isNavigation(i)).reduce((a: any, b: any) => a && b, true) : false);
       }
       """
     }
@@ -141,7 +141,7 @@ class TsGuardRendererSpec extends FreeSpec with Matchers {
     TypescriptGuard.render(decl[Recursive2]) shouldBe {
       i"""
       export const isRecursive2 = (v: any): v is Recursive2 => {
-        return typeof v === "object" && v != null && "head" in v && typeof v.head === "number" && "tail" in v && Array.isArray(v.tail) && v.tail.map((i: any) => isRecursive2(i)).reduce((a: any, b: any) => a && b);
+        return typeof v === "object" && v != null && "head" in v && typeof v.head === "number" && "tail" in v && Array.isArray(v.tail) && v.tail.map((i: any) => isRecursive2(i)).reduce((a: any, b: any) => a && b, true);
       }
       """
     }


### PR DESCRIPTION
The missing argument causes an exception when reducing an empty array.